### PR TITLE
Import JSON tokens into SCSS variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The DataCamp Design System
 
+[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
+
 The working name is Waffles, but we're using `design-system` for internal findability.
 
 ## Initial setup

--- a/catalog.config.js
+++ b/catalog.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
-
+const sassJsonImporter = require('node-sass-json-importer');
 const modulesPath = path.resolve(__dirname);
 
 module.exports = {
@@ -30,6 +30,7 @@ module.exports = {
           {
             loader: 'sass-loader',
             options: {
+              importer: sassJsonImporter(),
               includePaths: [modulesPath],
               sourceMap: !dev,
             },

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,9 @@
 {
   "packages": ["packages/*"],
-  "version": "independent"
+  "version": "independent",
+  "publish": {
+    "ignoreChanges": [
+      "*.md"
+    ]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1740,7 +1740,8 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "3.1.0",
@@ -1786,12 +1787,14 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
     },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -1800,12 +1803,14 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -1820,6 +1825,7 @@
           "version": "1.1.1",
           "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -1979,6 +1985,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -2019,7 +2026,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -2054,7 +2062,8 @@
     "async-foreach": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+      "dev": true
     },
     "async-limiter": {
       "version": "1.0.0",
@@ -2065,7 +2074,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -2088,12 +2098,14 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
     },
     "axobject-query": {
       "version": "2.0.2",
@@ -3126,6 +3138,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -3157,6 +3170,7 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
       "requires": {
         "inherits": "~2.0.0"
       }
@@ -3576,7 +3590,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "catalog": {
       "version": "3.6.0",
@@ -4011,6 +4026,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -4137,7 +4153,8 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -5291,6 +5308,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -5468,7 +5486,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "delegate": {
       "version": "3.2.0",
@@ -5479,7 +5498,8 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -5742,6 +5762,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -6714,7 +6735,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -6823,7 +6845,8 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "eyes": {
       "version": "0.1.8",
@@ -7128,12 +7151,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -7749,6 +7774,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -7782,6 +7808,7 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -7797,6 +7824,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7805,6 +7833,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7817,6 +7846,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
       "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+      "dev": true,
       "requires": {
         "globule": "^1.0.0"
       }
@@ -7886,6 +7916,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -8280,6 +8311,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
       "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "dev": true,
       "requires": {
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
@@ -8293,6 +8325,97 @@
       "optional": true,
       "requires": {
         "delegate": "^3.1.2"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+            }
+          }
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            }
+          }
+        }
       }
     },
     "graceful-fs": {
@@ -8334,12 +8457,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -8349,6 +8474,7 @@
           "version": "6.6.1",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
           "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+          "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -8359,12 +8485,14 @@
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
         }
       }
     },
@@ -8397,7 +8525,8 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -8783,6 +8912,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -8920,7 +9050,8 @@
     "in-publish": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
+      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+      "dev": true
     },
     "indent-string": {
       "version": "2.1.0",
@@ -9383,10 +9514,17 @@
         "text-extensions": "^1.0.0"
       }
     },
+    "is-there": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/is-there/-/is-there-4.4.3.tgz",
+      "integrity": "sha1-osSTZsakh/cZ28rYDL3iEkjSwY0=",
+      "dev": true
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -9430,7 +9568,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-api": {
       "version": "1.3.7",
@@ -10491,7 +10630,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "jsdom": {
       "version": "11.12.0",
@@ -10558,7 +10698,8 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
@@ -10574,7 +10715,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json3": {
       "version": "3.3.2",
@@ -10609,6 +10751,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -11042,7 +11185,8 @@
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -11052,7 +11196,8 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -11085,7 +11230,8 @@
     "lodash.mergewith": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
+      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -11840,6 +11986,7 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
       "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+      "dev": true,
       "requires": {
         "fstream": "^1.0.0",
         "glob": "^7.0.3",
@@ -11859,6 +12006,7 @@
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
           "requires": {
             "abbrev": "1"
           }
@@ -11866,7 +12014,8 @@
         "semver": {
           "version": "5.3.0",
           "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
         }
       }
     },
@@ -11975,6 +12124,7 @@
       "version": "4.11.0",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
       "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+      "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
@@ -12000,12 +12150,14 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -12018,6 +12170,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+          "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "which": "^1.2.9"
@@ -12026,7 +12179,8 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -12034,6 +12188,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/node-sass-chokidar/-/node-sass-chokidar-1.3.4.tgz",
       "integrity": "sha512-AEKBr58QFzU37Ubud90K1n+ljEpTDekJm5UCS8ZyoWgHoz2qx8f2vAaN8rECbqF1vYPid64NZBh98AKzHh9D9A==",
+      "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
         "chokidar": "^2.0.4",
@@ -12043,6 +12198,34 @@
         "node-sass": "^4.9.3",
         "sass-graph": "^2.1.1",
         "stdout-stream": "^1.4.0"
+      }
+    },
+    "node-sass-json-importer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/node-sass-json-importer/-/node-sass-json-importer-4.0.1.tgz",
+      "integrity": "sha512-uTS/eTBq69HpAxtTmKXT0HJEc/4Y2BHuv3svVsqnjhlaqn2bEY0d6pZi5g+3gY/pbrh/R+vZ3/1hdVI19/MT6Q==",
+      "dev": true,
+      "requires": {
+        "is-there": "^4.0.0",
+        "json5": "^1.0",
+        "lodash": "^4.17"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
       }
     },
     "nomnom": {
@@ -12276,6 +12459,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -12310,7 +12494,8 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -12536,6 +12721,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -16316,7 +16502,8 @@
     "psl": {
       "version": "1.1.29",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "dev": true
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -16999,6 +17186,7 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -17293,6 +17481,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+      "dev": true,
       "requires": {
         "glob": "^7.0.0",
         "lodash": "^4.0.0",
@@ -17303,12 +17492,14 @@
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
         },
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
           "requires": {
             "string-width": "^1.0.1",
             "strip-ansi": "^3.0.1",
@@ -17319,6 +17510,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
           "requires": {
             "path-exists": "^2.0.0",
             "pinkie-promise": "^2.0.0"
@@ -17328,6 +17520,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -17336,6 +17529,7 @@
           "version": "1.1.0",
           "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "parse-json": "^2.2.0",
@@ -17348,6 +17542,7 @@
           "version": "1.4.0",
           "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
           "requires": {
             "lcid": "^1.0.0"
           }
@@ -17356,6 +17551,7 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
           "requires": {
             "error-ex": "^1.2.0"
           }
@@ -17364,6 +17560,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
@@ -17372,6 +17569,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "pify": "^2.0.0",
@@ -17381,12 +17579,14 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
         },
         "read-pkg": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
           "requires": {
             "load-json-file": "^1.0.0",
             "normalize-package-data": "^2.3.2",
@@ -17397,6 +17597,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
           "requires": {
             "find-up": "^1.0.0",
             "read-pkg": "^1.0.0"
@@ -17406,6 +17607,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -17416,6 +17618,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
           "requires": {
             "is-utf8": "^0.2.0"
           }
@@ -17423,12 +17626,14 @@
         "which-module": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
         },
         "yargs": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "dev": true,
           "requires": {
             "camelcase": "^3.0.0",
             "cliui": "^3.2.0",
@@ -17449,6 +17654,7 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true,
           "requires": {
             "camelcase": "^3.0.0"
           }
@@ -17504,6 +17710,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+      "dev": true,
       "requires": {
         "js-base64": "^2.1.8",
         "source-map": "^0.4.2"
@@ -17513,6 +17720,7 @@
           "version": "0.4.4",
           "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
           "requires": {
             "amdefine": ">=0.0.4"
           }
@@ -18071,6 +18279,7 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
       "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -18137,6 +18346,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
       "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
+      "dev": true,
       "requires": {
         "readable-stream": "^2.0.1"
       },
@@ -18144,12 +18354,14 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -18164,6 +18376,7 @@
           "version": "1.1.1",
           "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -18527,6 +18740,7 @@
       "version": "2.2.1",
       "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "dev": true,
       "requires": {
         "block-stream": "*",
         "fstream": "^1.0.2",
@@ -18911,6 +19125,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -18919,7 +19134,8 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
         }
       }
     },
@@ -18952,6 +19168,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
       "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.2"
       }
@@ -18971,6 +19188,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -18978,7 +19196,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -19340,6 +19559,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -19835,6 +20055,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "jest-styled-components": "6.3.1",
     "jest-transform-stub": "1.0.0",
     "lerna": "3.6.0",
+    "node-sass-chokidar": "1.3.4",
+    "node-sass-json-importer": "4.0.1",
     "npm-run-all": "4.1.5",
     "postcss-browser-reporter": "0.5.0",
     "postcss-import": "12.0.1",
@@ -65,7 +67,6 @@
   },
   "dependencies": {
     "catalog": "3.6.0",
-    "node-sass-chokidar": "1.3.4",
     "react": "16.6.3",
     "react-dom": "16.6.3"
   },

--- a/packages/core/scss/design/dc-utilities/_dc-utilities.scss
+++ b/packages/core/scss/design/dc-utilities/_dc-utilities.scss
@@ -75,6 +75,10 @@
  *   - padding vertical (.dc-u-pv])
  * - Position
  *   - position (.dc-u-pos)
+ *   - bottom: (.dc-u-bottom)
+ *   - left: (.dc-u-left)
+ *   - right: (.dc-u-right)
+ *   - top: (.dc-u-top)
  * - Table
  *   - table-layout (.dc-u-tbl-l)
  * - Text
@@ -1375,8 +1379,23 @@ $dc-overflow-types: 'auto', 'hidden', 'scroll', 'visible';
   top: 0 !important;
 }
 
-// TODO: do we want matching bottom, left, right, top utilities?
-// .dc-u-pos-top-x ?
+// bottom, left, right, top
+
+.dc-u-bottom-0 {
+  bottom: 0;
+}
+
+.dc-u-left-0 {
+  left: 0;
+}
+
+.dc-u-right-0 {
+  right: 0;
+}
+
+.dc-u-top-0 {
+  top: 0;
+}
 
 /** Table */
 

--- a/packages/core/scss/design/dc-variables-tokenized.scss
+++ b/packages/core/scss/design/dc-variables-tokenized.scss
@@ -1,0 +1,246 @@
+@import '../tokens.json';
+
+// *************************************
+//
+//   DC Globals
+//   -> Variables created for re-use globally
+//
+// *************************************
+
+/**
+ * Global Sass variables, all namespaced within "dc-". Must be included before
+ * any other partials and a critical path dependency for the styleguide.
+ */
+
+/** Spatial */
+
+$dc-multiplier: map_get($spatial, multiplier);
+
+// Spatial lists for generating utility classes
+$dc-spatial: map_get($spatial, sizes);
+$dc-spatial-common: map_get($spatial, commonSizes);
+$dc-measure: map_get($spatial, measure);
+$dc-spatial-all: join($list1: $dc-spatial, $list2: $dc-measure);
+
+// Percentages list for generating utility classes
+$dc-percentages: map_get($spatial, percentages);
+
+/** Color */
+
+// To add a new color, first add the variable then add the color name to the
+// $dc-colors map below which is used to generate utility classes.
+$dc-green: map_get($colors, green);
+$dc-green-light: map_get($colors, greenLight);
+$dc-geyser: map_get($colors, geyser);
+$dc-grey: map_get($colors, grey);
+$dc-grey-dark: map_get($colors, greyDark);
+$dc-grey-light: map_get($colors, greyLight);
+$dc-grey-lighter: map_get($colors, greyLighter);
+$dc-grey-oslo: map_get($colors, greyOslo);
+$dc-orange: map_get($colors, orange);
+$dc-orange-dark: map_get($colors, orangeDark);
+$dc-porcelain: map_get($colors, porcelain);
+$dc-primary: map_get($colors, primary);
+$dc-primary-dark: map_get($colors, primaryDark);
+$dc-primary-darker: map_get($colors, primaryDarker);
+$dc-primary-darkest: map_get($colors, primaryDarkest);
+$dc-primary-light: map_get($colors, primaryLight);
+$dc-primary-lighter: map_get($colors, primaryLighter);
+$dc-primary-lightest: map_get($colors, primaryLightest);
+$dc-purple: map_get($colors, purple);
+$dc-purple-dark: map_get($colors, purpleDark);
+$dc-purple-light: map_get($colors, purpleLight);
+$dc-raven: map_get($colors, raven);
+$dc-red: map_get($colors, red);
+$dc-red-light: map_get($colors, redLight);
+$dc-secondary: map_get($colors, secondary);
+$dc-secondary-light: map_get($colors, secondaryLight);
+$dc-white: map_get($colors, white);
+$dc-white-transparent: map_get($colors, whiteTransparent);
+
+// Color map
+/* stylelint-disable scss/at-function-named-arguments */
+$dc-colors: (
+  'green': $dc-green,
+  'green-light': $dc-green-light,
+  'geyser': $dc-geyser,
+  'grey': $dc-grey,
+  'grey-dark': $dc-grey-dark,
+  'grey-light': $dc-grey-light,
+  'grey-lighter': $dc-grey-lighter,
+  'grey-oslo': $dc-grey-oslo,
+  'orange': $dc-orange,
+  'orange-dark': $dc-orange-dark,
+  'porcelain': $dc-porcelain,
+  'primary': $dc-primary,
+  'primary-dark': $dc-primary-dark,
+  'primary-darker': $dc-primary-darker,
+  'primary-darkest': $dc-primary-darkest,
+  'primary-light': $dc-primary-light,
+  'primary-lighter': $dc-primary-lighter,
+  'primary-lightest': $dc-primary-lightest,
+  'purple': $dc-purple,
+  'purple-dark': $dc-purple-dark,
+  'purple-light': $dc-purple-light,
+  'raven': $dc-raven,
+  'red': $dc-red,
+  'red-light': $dc-red-light,
+  'secondary': $dc-secondary,
+  'secondary-light': $dc-secondary-light,
+  'white': $dc-white,
+  'white-transparent': $dc-white-transparent,
+  'currentColor': currentColor,
+  'transparent': transparent
+);
+/* stylelint-enable */
+
+/** Gradient */
+
+// to be deprecated?
+$dc-gradient-chambray-cloudburst: map_get($gradients, chambrayCloudburst);
+$dc-gradient-puertorico-deyork: map_get($gradients, puertoricoDeyork);
+
+$dc-gradient-blue-light: map_get($gradients, blueLight);
+$dc-gradient-green: $dc-gradient-puertorico-deyork;
+$dc-gradient-grey: map_get($gradients, grey);
+$dc-gradient-primary: map_get($gradients, primary);
+$dc-gradient-primary-dark: map_get($gradients, primaryDark);
+$dc-gradient-primary-light: map_get($gradients, primaryLight);
+$dc-gradient-purple: map_get($gradients, purple);
+$dc-gradient-red: map_get($gradients, red);
+$dc-gradient-red-light: map_get($gradients, redLight);
+$dc-gradient-secondary: map_get($gradients, secondary);
+$dc-gradient-turquoise: map_get($gradients, turquoise);
+
+/** Typography */
+
+// Font family
+$dc-font-family-sans-serif: map_get($fontFamily, sansSerif);
+$dc-font-family-mono: map_get($fontFamily, mono);
+
+// Font size
+$dc-font-size-base: map_get($fontSize, base);
+$dc-font-size-micro: map_get($fontSize, micro);
+$dc-font-size-small: map_get($fontSize, small);
+
+// Heading size
+$dc-font-size-h1: map_get($fontSize, h1);
+$dc-font-size-h2: map_get($fontSize, h2);
+$dc-font-size-h3: map_get($fontSize, h3);
+$dc-font-size-h4: map_get($fontSize, h4);
+$dc-font-size-h5: map_get($fontSize, h5);
+$dc-font-size-h6: map_get($fontSize, h6);
+
+// Font weight
+$dc-font-weight-bold: map_get($fontWeight, bold);
+$dc-font-weight-light: map_get($fontWeight, light);
+$dc-font-weight-regular: map_get($fontWeight, regular);
+
+// Line height
+$dc-line-height-base: map_get($lineHeight, base);
+$dc-line-height-heading: map_get($lineHeight, heading);
+
+/** Border */
+
+$dc-border-radius: map_get($border, radius);
+
+/** Box shadow */
+
+// Box shadow color
+$dc-box-shadow-color:  map_get($boxShadow, color);
+
+// Box shadows
+$dc-box-shadow-border: map_get($boxShadow, border);
+$dc-box-shadow-sm: map_get($boxShadow, sm);
+$dc-box-shadow-md: map_get($boxShadow, md);
+$dc-box-shadow-lg: map_get($boxShadow, lg);
+$dc-box-shadow-xl: map_get($boxShadow, xl);
+$dc-box-shadow-xxl: map_get($boxShadow, xxl);
+$dc-box-shadow-xl-green: map_get($boxShadow, xlGreen);
+$dc-box-shadow-xl-orange: map_get($boxShadow, xlOrange);
+$dc-box-shadow-xl-purple: map_get($boxShadow, xlPurple);
+
+/** Transform */
+
+$dc-angles: map_get($spatial, angles);
+
+/** Animation */
+
+$dc-duration: map_get($animation, duration);
+$dc-ease: map_get($animation, ease);
+$dc-transition: map_get($animation, transition);
+
+/** z-index */
+
+$dc-z-indexes: map_get($spatial, zIndex);
+
+/** Breakpoints */
+
+$dc-bp-xs: map_get($breakpoints, xs);
+$dc-bp-sm: map_get($breakpoints, sm);
+$dc-bp-md: map_get($breakpoints, md);
+$dc-bp-lg: map_get($breakpoints, lg);
+$dc-bp-xl: map_get($breakpoints, xl);
+$dc-bp-ws: map_get($breakpoints, ws);
+$dc-bp-4k: map_get($breakpoints, 4k);
+$dc-bp-5k: map_get($breakpoints, 5k);
+
+// Breakpoints for max-width media queries
+$dc-bp-below-xs: map_get($breakpoints, belowXs);
+$dc-bp-below-sm: map_get($breakpoints, belowSm);
+$dc-bp-below-md: map_get($breakpoints, belowMd);
+$dc-bp-below-lg: map_get($breakpoints, belowLg);
+$dc-bp-below-xl: map_get($breakpoints, belowXl);
+$dc-bp-below-ws: map_get($breakpoints, belowWs);
+$dc-bp-below-4k: map_get($breakpoints, below4k);
+$dc-bp-below-5k: map_get($breakpoints, below5k);
+
+// Breakpoints map
+/* stylelint-disable scss/at-function-named-arguments */
+$dc-breakpoints: (
+  'xs': $dc-bp-xs,
+  'sm': $dc-bp-sm,
+  'md': $dc-bp-md,
+  'lg': $dc-bp-lg,
+  'xl': $dc-bp-xl
+);
+
+// hd breakpoints
+$dc-breakpoints-hd: (
+  'ws': $dc-bp-ws,
+  '4k': $dc-bp-4k,
+  '5k': $dc-bp-5k
+);
+
+// all breakpoints
+$dc-breakpoints-all: map-merge($dc-breakpoints, $dc-breakpoints-hd);
+
+// Breakpoints for max-width map
+$dc-breakpoints-below: (
+  'xs': $dc-bp-below-xs,
+  'sm': $dc-bp-below-sm,
+  'md': $dc-bp-below-md,
+  'lg': $dc-bp-below-lg,
+  'xl': $dc-bp-below-xl
+);
+
+// hd max-width breakpoints
+$dc-breakpoints-below-hd: (
+  'ws': $dc-bp-below-ws,
+  '4k': $dc-bp-below-4k,
+  '5k': $dc-bp-below-5k
+);
+
+// all max-width breakpoints
+$dc-breakpoints-below-all: map-merge($dc-breakpoints-below, $dc-breakpoints-below-hd);
+/* stylelint-enable */
+
+// Sides
+/* stylelint-disable scss/at-function-named-arguments */
+$dc-sides: (
+  't': top,
+  'r': right,
+  'b': bottom,
+  'l': left,
+);
+/* stylelint-enable */

--- a/packages/core/tokens.json
+++ b/packages/core/tokens.json
@@ -1,0 +1,117 @@
+{
+  "spatial": {
+    "multiplier": "2",
+    "sizes": "'2 4 8 12 16 24 32 48 64 80 96 128'",
+    "commonSizes": "'8 12 16 24 32 48 64'",
+    "measure": "'192 256 320 480 640 800 960'",
+    "percentages": "'1 5 10 15 20 25 30 40 44 50 60 70 75 80 90 100'",
+    "angles": "'30 45 60 90 180 270 360'",
+    "zIndex": "'10 20 30 40 50 60 70 80 90 100 999'"
+  },
+  "colors": {
+    "green": "#36d57d",
+    "greenLight": "#a5ecc5",
+    "geyser": "#cfdce1",
+    "grey": "#686f75",
+    "greyDark": "#3d4251",
+    "greyLight": "#d1d3d8",
+    "greyLighter": "#e6eaeb",
+    "greyOslo": "#859094",
+    "orange": "#ff9400",
+    "orangeDark": "#ad662c",
+    "porcelain": "#f0f4f5",
+    "primary": "#3ac",
+    "primaryDark": "#263e63",
+    "primaryDarker": "#14243e",
+    "primaryDarkest": "#0c1626",
+    "primaryLight": "#7ecce2",
+    "primaryLighter": "#d5eaef",
+    "primaryLightest": "#ebf4f7",
+    "purple": "#8468c4",
+    "purpleDark": "#5d488c",
+    "purpleLight": "#a786f3",
+    "raven": "#737a80",
+    "red": "#fe5c5c",
+    "redLight": "#ffb5b5",
+    "secondary": "#ffc844",
+    "secondaryLight": "#fbe28d",
+    "white": "#fff",
+    "whiteTransparent": "'rgba(255, 255, 255, 0.2)'"
+  },
+  "gradients": {
+    "chambrayCloudburst": "'linear-gradient(268deg, #405f8f, #1c3050)'",
+    "puertoricoDeyork": "'linear-gradient(32deg, #37bbab, #75c97e)'",
+    "blueLight": "'linear-gradient(-143deg, #7dd4e7, #7099d7 100%)'",
+    "grey": "'linear-gradient(-135deg, #e7f1f6, #b6d1e5)'",
+    "primary": "'linear-gradient(141deg, #2388b0, #3ac)'",
+    "primaryDark": "'linear-gradient(141deg, #20748d, #164d62)'",
+    "primaryLight": "'linear-gradient(180deg, rgba(255, 255, 255, 0), rgba(51, 170, 204, 0.075))'",
+    "purple": "'linear-gradient(-136deg, #c06ac8, #8468c4)'",
+    "red": "'linear-gradient(45deg, #f06a8c, #f6a38d)'",
+    "redLight": "'linear-gradient(180deg, rgba(255, 255, 255, 0), rgba(254, 92, 92, 0.075))'",
+    "secondary": "'linear-gradient(0deg, #ffc844, #fcd86c)'",
+    "turquoise": "'linear-gradient(-135deg, #b8eef4, #78c8de)'"
+  },
+  "fontFamily": {
+    "sansSerif": "'lato, sans-serif'",
+    "mono": "'Roboto Mono, monospace'"
+  },
+  "fontSize": {
+    "base": "16px",
+    "micro": "0.75rem",
+    "small": "0.875rem",
+    "h1": "2.5rem",
+    "h2": "2rem",
+    "h3": "1.5rem",
+    "h4": "1.25rem",
+    "h5": "1.125rem",
+    "h6": "1rem"
+  },
+  "fontWeight": {
+    "bold": "700",
+    "light": "300",
+    "regular": "400"
+  },
+  "lineHeight": {
+    "base": "1.5",
+    "heading": "1.25"
+  },
+  "border": {
+    "radius": "4px"
+  },
+  "boxShadow": {
+    "color": "'rgba(0, 0, 0, 0.15)'",
+    "border": "'0 0 0 1px #e6eaeb'",
+    "sm": "'0 1px 2px 0 rgba(0, 0, 0, 0.15)'",
+    "md": "'0 1px 3px 0 rgba(0, 0, 0, 0.15)'",
+    "lg": "'0 3px 5px 0 rgba(0, 0, 0, 0.15)'",
+    "xl": "'0 4px 8px 0 rgba(0, 0, 0, 0.15)'",
+    "xxl": "'0 10px 20px 0 rgba(0, 0, 0, 0.15)'",
+    "xlGreen": "'0 4px 8px 0 rgba(54, 213, 125, 0.3)'",
+    "xlOrange": "'0 4px 8px 0 rgba(255, 148, 0, 0.3)'",
+    "xlPurple": "'0 4px 8px 0 rgba(132, 104, 196, 0.3)'"
+  },
+  "animation": {
+    "duration": "0.3s",
+    "ease": "'cubic-bezier(0.77, 0, 0.175, 1)'",
+    "transition": "'0.3s cubic-bezier(0.77, 0, 0.175, 1)'"
+  },
+  "breakpoints": {
+    "xs": "480px",
+    "sm": "768px",
+    "md": "992px",
+    "lg": "1200px",
+    "xl": "1366px",
+    "ws": "1680px",
+    "4K": "1920px",
+    "5K": "2560px",
+    "belowXs": "479px",
+    "belowSm": "767px",
+    "belowMd": "991px",
+    "belowLg": "1199px",
+    "belowXl": "1365px",
+    "belowWs": "1679px",
+    "below4K": "1919px",
+    "below5K": "2559px"
+  }
+}


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to project maintainers, then
provide any implementation and technical details. Also please list any potential
problems or considerations and tag team members you'd like input from. -->

- Create JSON design tokens
- Import these JSON design tokens into `dc-variables-tokenized.scss`
- Consume the tokens in `dc-variables-tokenized` using `map_get($object, key)`
- Set `lerna publish` to ignore changes to `.md` files (readme's etc.)
- Moved `node-sass-chokidar` to `devDependencies` as it'll never be needed on a prod server (only dev and CI for builds).
- Snuck in four util classes:
  - `dc-u-bottom-0`
  - `dc-u-left-0`
  - `dc-u-right-0`
  - `dc-u-top-0`
- Suggested we deprecate `chambrayCloudburst` and `puertoricoDeyork` in favour of `primaryDark` and `green` respectively — I think this is correct, but we'd need to double check as CC and PD are slightly different in some places.

@dandenney @jordanwade the fairly major caveat here is that based on the code in this PR, `main-app` couldn't just import `ingredients.scss` as is and have it work. This is because `main-app` isn't set up to consume JSON in SCSS files the way this repo is.

Three possible solutions:
- Any app that wants to consume `dc-variables.scss` has to be able to consume `tokens.json` via Webpack config (`main-app` uses [Webpacker](https://github.com/rails/webpacker) for this).
- We build `waffles-core` in such a way that when it's published the JSON values are interpolated and replaced with their values (no need to add to Webpack configs)
- We do something similar but we have a `dc-variables.scss` and `dc-variables-no-tokens.scss`, one which works as the current one does and one that has no dependency on SCSS JSON evaluation.

LMK your thoughts.

@jordanwade if you can port `colors.js`, `iconNames.js` and `index.js` into `packages/core/js` (rather than the `/core` root), then I can import the tokens into those files to get us to a single source-of-truth. I know it's a bit of a pain as you're already referencing them in the other package, but I think we'll benefit from the tidy house-keeping long-term. Thanks!

### Related issues
<!-- Links to issues in this and any other repos.-->

#1 

### Types of changes
<!-- Indicate all types of changes this PR introduces (_tick all that apply_): -->

- [ ] Bugfix (patch, non-breaking, e.g. v1.1.1 > v1.1.2)
- [x] New feature (minor, non-breaking, e.g. v1.1.1 > v1.2.0)
- [ ] **Breaking change** (major, e.g. v1.1.1 > v2.0.0)

## Checklist
<!-- Strikethrough any below that are not applicable. -->

- [x] Manual testing on desktop/dev.datacamp.com
- [ ] ~~Changes are covered by automated tests~~
- [ ] ~~Necessary documentation added (if appropriate)~~
- [x] PR is assigned to yourself or another developer
- [x] PR is connected to GH Issue
- [x] PR has at least one reviewer
