### PR TITLE
chore(*): Copy and update the config from the style guide

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: |
             export AWS_ACCESS_KEY_ID=${STAGING_AWS_ACCESS_KEY_ID}
             export AWS_SECRET_ACCESS_KEY=${STAGING_AWS_SECRET_ACCESS_KEY}
-            aws s3 sync --delete --acl public-read dist s3://${BUCKET}.datacamp-staging.com/live
+            aws s3 sync --delete --acl public-read catalog/build s3://${BUCKET}.datacamp-staging.com/live
             aws s3 sync --acl public-read catalog/build/static/images s3://waffles.datacamp-staging.com/live/images
   deploy:
     docker:
@@ -48,7 +48,7 @@ jobs:
           command: |
             export AWS_ACCESS_KEY_ID=${PROD_AWS_ACCESS_KEY_ID}
             export AWS_SECRET_ACCESS_KEY=${PROD_AWS_SECRET_ACCESS_KEY}
-            aws s3 sync --delete --exclude "*le-components/*" --acl public-read dist s3://${BUCKET}.new.datacamp.com/live
+            aws s3 sync --delete --exclude "*le-components/*" --acl public-read catalog/build s3://${BUCKET}.new.datacamp.com/live
             aws s3 sync --acl public-read catalog/build/static/images s3://waffles.new.datacamp.com/live/images
 workflows:
   version: 2


### PR DESCRIPTION
## Proposed changes
This is a replica of the style guide CircleCI config, with updated values for the build locations in Catalog. We're not currently shipping images but they will reside in `catalog/static/images` when we do.

### Related issues
<!-- Links to issues in this and any other repos.-->

https://github.com/datacamp/devops/issues/642

### Types of changes
<!-- Indicate all types of changes this PR introduces (_tick all that apply_): -->

- [ ] Bugfix (patch, non-breaking, e.g. v1.1.1 > v1.1.2)
- [x] New feature (minor, non-breaking, e.g. v1.1.1 > v1.2.0)
- [ ] **Breaking change** (major, e.g. v1.1.1 > v2.0.0)

## Checklist
<!-- Strikethrough any below that are not applicable. -->

- [ ] Manual testing on desktop/dev.datacamp.com
- [ ] Changes are covered by automated tests
- [ ] Necessary documentation added (if appropriate)
- [x] PR is assigned to yourself or another developer
- [ ] PR is connected to GH Issue
- [ ] PR has at least one reviewer


