### PR TITLE
refactor(design): Add height to the text input class, scoped to IE

### DIFF
--- a/packages/core/scss/design/forms/_forms-legacy.scss
+++ b/packages/core/scss/design/forms/_forms-legacy.scss
@@ -74,6 +74,12 @@
   }
 }
 
+@media all and (-ms-high-contrast: none) {
+  .dc-input--text {
+    height: 48px;
+  }
+}
+
 // Date input
 
 .dc-input--date {


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to project maintainers, then
provide any implementation and technical details. Also please list any potential
problems or considerations and tag team members you'd like input from. -->
This sets the height of inputs that use our text input class `dc-input--text` to `48p`, using an IE media query. As @kspe pointed out in a main-app PR, line-height is not properly factored into the height of an input in IE.

### Types of changes
<!-- Indicate all types of changes this PR introduces (_tick all that apply_): -->

- [x] Bugfix (patch, non-breaking, e.g. v1.1.1 > v1.1.2)
- [ ] New feature (minor, non-breaking, e.g. v1.1.1 > v1.2.0)
- [ ] **Breaking change** (major, e.g. v1.1.1 > v2.0.0)

## Checklist
<!-- Strikethrough any below that are not applicable. -->

- [ ] Manual testing on desktop/dev.datacamp.com
- [ ] Changes are covered by automated tests
- [ ] Necessary documentation added (if appropriate)
- [x] PR is assigned to yourself or another developer
- [ ] PR is connected to GH Issue
- [x] PR has at least one reviewer

### UI Changes

- [x] PR is cross-browser tested
- [x] PR has screenshots attached

## Screenshots
<!-- If related to UI changes then upload screenshots here. Omit if no UI changes. -->

##### Before
<img width="1068" alt="screenshot 2019-01-22 07 48 16" src="https://user-images.githubusercontent.com/283611/51536729-858b6980-1e1a-11e9-9159-a4aec2da79da.png">

##### After 
<img width="1069" alt="screenshot 2019-01-22 07 47 35" src="https://user-images.githubusercontent.com/283611/51536737-8c19e100-1e1a-11e9-9c80-542fa6662b15.png">