### PR TITLE
fix(Core): Add black to colors and remove '

### DIFF
--- a/catalog/pages/design-utilities/background.js
+++ b/catalog/pages/design-utilities/background.js
@@ -18,23 +18,30 @@ export default () => {
 
       <Page>
         <section>
-          <p>Background color utility classes are named using the format <code>.dc-u-bgc-[color-name]</code>. They can be used for building or customizing an element.</p>
+          <p>
+            Background color utility classes are named using the format{' '}
+            <code>.dc-u-bgc-[color-name]</code>. They can be used for building
+            or customizing an element.
+          </p>
 
           <ul className="dc-u-fx dc-u-fx-fww dc-u-m-none dc-u-p-none">
-            {obj.map(name => (
-              <li
-                className="dc-u-fx dc-u-fx-fdc dc-u-fx-aic dc-u-fx-jcc"
-                key={name}
-                style={{
-                  background: getColor(name),
-                  width: '256px',
-                  height: '128px',
-                  color: getContrastColor(name),
-                }}
-              >
-                <code>{`.dc-u-bgc-${dashify(name)}`}</code>
-              </li>
-            ))}
+            {obj.map(name => {
+              console.log(getColor(name));
+              return (
+                <li
+                  className="dc-u-fx dc-u-fx-fdc dc-u-fx-aic dc-u-fx-jcc"
+                  key={name}
+                  style={{
+                    background: getColor(name),
+                    width: '256px',
+                    height: '128px',
+                    color: getContrastColor(name),
+                  }}
+                >
+                  <code>{`.dc-u-bgc-${dashify(name)}`}</code>
+                </li>
+              );
+            })}
           </ul>
         </section>
       </Page>

--- a/packages/core/js/colors.js
+++ b/packages/core/js/colors.js
@@ -4,6 +4,10 @@ import tokens from '../tokens.json';
 const { colors } = tokens;
 
 const COLORS = {
+  blackTransparent: {
+    color: colors.blackTransparent,
+    contrastColor: colors.white,
+  },
   green: {
     color: colors.green,
     contrastColor: colors.white,

--- a/packages/core/scss/design/variables.scss
+++ b/packages/core/scss/design/variables.scss
@@ -63,6 +63,7 @@ $dc-white-transparent: map_get($colors, whiteTransparent);
 // Color map
 /* stylelint-disable scss/at-function-named-arguments */
 $dc-colors: (
+  'black-transparent': $dc-black-transparent,
   'green': $dc-green,
   'green-light': $dc-green-light,
   'geyser': $dc-geyser,

--- a/packages/core/tokens.json
+++ b/packages/core/tokens.json
@@ -9,7 +9,7 @@
     "zIndex": "10 20 30 40 50 60 70 80 90 100 999"
   },
   "colors": {
-    "blackTransparent": "'rgba(0, 0, 0, 0.2)'",
+    "blackTransparent": "rgba(0, 0, 0, 0.2)",
     "green": "#36d57d",
     "greenLight": "#a5ecc5",
     "geyser": "#cfdce1",
@@ -37,7 +37,7 @@
     "secondary": "#ffc844",
     "secondaryLight": "#fbe28d",
     "white": "#fff",
-    "whiteTransparent": "'rgba(255, 255, 255, 0.2)'"
+    "whiteTransparent": "rgba(255, 255, 255, 0.2)"
   },
   "gradients": {
     "chambrayCloudburst": "linear-gradient(268deg, #405f8f, #1c3050)",


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to project maintainers, then
provide any implementation and technical details. Also please list any potential
problems or considerations and tag team members you'd like input from. -->
I _thought_ I had added `$blackTransparent` but this time I really did. And removing the `'` fixes the bgc on the utilities page.

### Types of changes
<!-- Indicate all types of changes this PR introduces (_tick all that apply_): -->

- [x] Bugfix (patch, non-breaking, e.g. v1.1.1 > v1.1.2)
- [ ] New feature (minor, non-breaking, e.g. v1.1.1 > v1.2.0)
- [ ] **Breaking change** (major, e.g. v1.1.1 > v2.0.0)

## Checklist
<!-- Strikethrough any below that are not applicable. -->

- [ ] Manual testing on desktop/dev.datacamp.com
- [ ] Changes are covered by automated tests
- [ ] Necessary documentation added (if appropriate)
- [x] PR is assigned to yourself or another developer
- [ ] PR is connected to GH Issue
- [x] PR has at least one reviewer

### UI Changes

- [ ] PR is cross-browser tested
- [x] PR has screenshots attached

## Screenshots
<!-- If related to UI changes then upload screenshots here. Omit if no UI changes. -->
<img width="1101" alt="Screenshot 2019-04-08 18 00 21" src="https://user-images.githubusercontent.com/283611/55760257-8d29da00-5a29-11e9-94d6-14cd9e1b6331.png">
