### PR TITLE
Chore/public ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
           aws_secret_access_key: $STAGING_AWS_SECRET_ACCESS_KEY
     environment:
       BUCKET: waffles
+      CLOUDFRONT_ID: E16EOD0ZWD0L66
     steps:
       - attach_workspace:
           at: "."
@@ -48,6 +49,12 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=${STAGING_AWS_SECRET_ACCESS_KEY}
             aws s3 sync --delete --acl public-read packages/docs/catalog-doc-site/catalog/build s3://${BUCKET}.datacamp-staging.com/live
             #aws s3 sync --acl public-read packages/docs/catalog-doc-site/catalog/build/static/media s3://${BUCKET}.datacamp-staging.com/live/media
+      - run:
+          name: Invalidate Cache
+          command: |
+            export AWS_ACCESS_KEY_ID=$STAGING_AWS_ACCESS_KEY_ID
+            export AWS_SECRET_ACCESS_KEY=$STAGING_AWS_SECRET_ACCESS_KEY
+            aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_ID} --paths "/index.html"
   deploy-doc-site:
     docker:
       - image: ${STAGING_ECR_URL}/docker-deploy
@@ -56,6 +63,7 @@ jobs:
           aws_secret_access_key: $STAGING_AWS_SECRET_ACCESS_KEY
     environment:
       BUCKET: waffles
+      CLOUDFRONT_ID: E596C189UKISL
     steps:
       - attach_workspace:
           at: "."
@@ -66,6 +74,13 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=${PROD_AWS_SECRET_ACCESS_KEY}
             aws s3 sync --delete --exclude "*le-components/*" --acl public-read packages/docs/catalog-doc-site/catalog/build s3://${BUCKET}.new.datacamp.com/live
             #aws s3 sync --acl public-read packages/docs/catalog-doc-site/catalog/build/static/media s3://${BUCKET}.new.datacamp.com/live/media
+      - run:
+          name: Invalidate Cache
+          command: |
+            export AWS_ACCESS_KEY_ID=$PROD_AWS_ACCESS_KEY_ID
+            export AWS_SECRET_ACCESS_KEY=$PROD_AWS_SECRET_ACCESS_KEY
+            aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_ID} --paths "/index.html"
+
 workflows:
   version: 2
   build_and_deploy:


### PR DESCRIPTION
## Proposed changes
- Only deploys docs to production when there is a tag. This will keep docs in sync with published packages
- Invalidates cache on either staging or production after deployment of doc site.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
