### PR TITLE
[WF-138] expose es module as well as common js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ zip
 .DS_Store
 Thumbs.db
 tmp
+es
+types

--- a/packages/react-components/icons/gulpfile.js
+++ b/packages/react-components/icons/gulpfile.js
@@ -167,17 +167,26 @@ const generateTypescriptMobile = series(
 
 function transpileToJS() {
   return src('./build/**')
-    .pipe(babel({ configFile: './babel7.config.js' }))
+    .pipe(babel({ configFile: './babel7.config.js', envName: 'cjs' }))
     .pipe(dest('./lib'));
+}
+function transpileToES() {
+  return src('./build/**')
+    .pipe(babel({ configFile: './babel7.config.js', envName: 'es' }))
+    .pipe(dest('./es'));
 }
 
 function createTypings() {
   const tsProject = ts.createProject('tsconfig.json');
   const tsResult = src('./build/**').pipe(tsProject());
-  return tsResult.dts.pipe(dest('./lib'));
+  return tsResult.dts.pipe(dest('./lib')).pipe(dest('./es'));
 }
 
-const transpileTypescript = parallel(transpileToJS, createTypings);
+const transpileTypescript = parallel(
+  transpileToJS,
+  transpileToES,
+  createTypings
+);
 
 function generateSprites() {
   return loadAllSVGs()

--- a/packages/react-components/icons/package.json
+++ b/packages/react-components/icons/package.json
@@ -2,6 +2,7 @@
   "name": "@datacamp/waffles-icons",
   "version": "1.1.0",
   "main": "lib/web/index.js",
+  "module": "es/web/index.js",
   "license": "ISC",
   "sideEffects": false,
   "repository": {
@@ -10,7 +11,7 @@
   },
   "scripts": {
     "build": "gulp build",
-    "clean": "rm -rf build && rm -rf lib && rm -rf sprites && rm -rf zip",
+    "clean": "rm -rf build lib sprites zip es",
     "prepare": "yarn clean && yarn build",
     "type-check": "tsc --rootDir build --noEmit"
   },

--- a/packages/react-components/tag/package.json
+++ b/packages/react-components/tag/package.json
@@ -3,20 +3,23 @@
   "version": "0.4.0",
   "description": "Creates a small tag element for things like XP points.",
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "types": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/datacamp-engineering/design-system/tree/master/packages/react-components/tag/"
   },
   "scripts": {
-    "build:js": "babel src --extensions '.tsx','.ts' --out-dir lib --ignore src/**/*.spec.tsx --config-file ./babel7.config.js",
+    "build:cjs": "BABEL_ENV=cjs babel src --extensions '.tsx','.ts' --out-dir lib --ignore src/**/*.spec.tsx --config-file ./babel7.config.js",
+    "build:es": "BABEL_ENV=es babel src --extensions '.tsx','.ts' --out-dir es --ignore src/**/*.spec.tsx --config-file ./babel7.config.js",
     "build:legacy": "copyfiles -u 1 legacy/*.scss lib",
-    "clean": "rm -rf lib",
-    "build:types": "tsc --rootDir src --declarationDir lib --emitDeclarationOnly",
-    "build": "yarn build:types && yarn build:js && yarn build:legacy",
+    "clean": "rm -rf lib es types",
+    "build:types": "tsc --rootDir src --declarationDir types --emitDeclarationOnly",
+    "build": "yarn build:types && yarn build:es && yarn build:cjs && yarn build:legacy",
     "prepare": " yarn clean && yarn build",
     "test": "jest",
     "type-check": "tsc --noEmit",
-    "watch": "yarn build:js --watch"
+    "watch": "yarn build:es --watch"
   },
   "keywords": [],
   "author": "DataCamp",

--- a/packages/react-components/text/package.json
+++ b/packages/react-components/text/package.json
@@ -2,19 +2,22 @@
   "name": "@datacamp/waffles-text",
   "version": "0.8.0",
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "types": "types/index.d.ts",
   "license": "UNLICENSED",
   "sideEffects": [
     "lib/sideEffects/*"
   ],
   "scripts": {
-    "build:js": "babel src --extensions '.tsx','.ts' --out-dir lib --ignore \"src/**/*.spec.tsx\",\"src/**/*.spec.ts\" --config-file ./babel7.config.js",
-    "clean": "rm -rf lib",
-    "build:types": "tsc --rootDir src --declarationDir lib --emitDeclarationOnly",
-    "build": "yarn build:types && yarn build:js",
+    "build:cjs": "BABEL_ENV=cjs babel src --extensions '.tsx','.ts' --out-dir lib --ignore \"src/**/*.spec.tsx\",\"src/**/*.spec.ts\" --config-file ./babel7.config.js",
+    "build:es": "BABEL_ENV=es babel src --extensions '.tsx','.ts' --out-dir es --ignore \"src/**/*.spec.tsx\",\"src/**/*.spec.ts\" --config-file ./babel7.config.js",
+    "clean": "rm -rf lib es types",
+    "build:types": "tsc --rootDir src --declarationDir types --emitDeclarationOnly",
+    "build": "yarn build:types && yarn build:cjs && yarn build:es",
     "prepare": " yarn clean && yarn build",
     "test": "jest",
     "type-check": "tsc --noEmit",
-    "watch": "yarn build:js --watch"
+    "watch": "yarn build:es --watch"
   },
   "devDependencies": {
     "@babel/cli": "7.5.0",

--- a/packages/tools/babel-preset/index.js
+++ b/packages/tools/babel-preset/index.js
@@ -7,19 +7,35 @@ const pluginTypescriptToProptypes = require('babel-plugin-typescript-to-proptype
   .default;
 const pluginTransformRuntime = require('@babel/plugin-transform-runtime');
 
+const targets = {
+  browsers: ['last 2 versions', 'Firefox ESR', 'not IE < 11'],
+};
+
 module.exports = () => ({
+  env: {
+    cjs: {
+      presets: [
+        [
+          presetEnv,
+          {
+            modules: 'cjs',
+            targets,
+          },
+        ],
+      ],
+    },
+    es: {
+      presets: [
+        [
+          presetEnv,
+          {
+            modules: false,
+            targets,
+          },
+        ],
+      ],
+    },
+  },
   plugins: [pluginLodash, pluginTypescriptToProptypes, pluginTransformRuntime],
-  presets: [
-    [
-      presetEnv,
-      {
-        targets: {
-          browsers: ['last 2 versions', 'Firefox ESR', 'not IE < 11'],
-        },
-      },
-    ],
-    presetReact,
-    presetTypescript,
-    presetCSSProp,
-  ],
+  presets: [[presetEnv], presetReact, presetTypescript, presetCSSProp],
 });


### PR DESCRIPTION
## Proposed changes
Adds es module as target so tree shaking can work as intended.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
