### PR TITLE
[WF-150] Separate percy from other tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ jobs:
       - run:
           name: Check types
           command: yarn type-check
+      - run:
+          name: Upload to percy
+          command: yarn percy
       - persist_to_workspace:
           root: "."
           paths:

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
   },
   "main": "catalog/index.js",
   "scripts": {
-    "bootstrap": "lerna clean --yes && lerna bootstrap && lerna run prepare",
+    "bootstrap": "lerna clean --yes && lerna bootstrap && lerna run prepare --stream",
     "lint": "svglint \"./packages/react-components/**/!(sprite)*.svg\" && eslint --ext js,jsx,ts,tsx --ignore-path .gitignore .",
     "lint:fix": "yarn lint --fix",
-    "test": "lerna run test",
+    "test": "lerna run test --stream",
+    "percy": "lerna run percy",
     "type-check": "lerna run type-check",
     "build": "lerna run build",
     "publish-packages": "lerna publish --conventional-commits --create-release github",

--- a/packages/docs/storybook/package.json
+++ b/packages/docs/storybook/package.json
@@ -10,7 +10,7 @@
     "build": "build-storybook -c .storybook -o lib",
     "clean": "rm -rf lib",
     "prepare": "yarn clean && yarn build",
-    "test": "percy-storybook --fail_on_empty=true --build_dir=lib --widths=320,1280"
+    "percy": "percy-storybook --fail_on_empty=true --build_dir=lib --widths=320,1280"
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",


### PR DESCRIPTION
- adds separate percy command to be run in ci, excluding it from main 
test command
- streams build and test results to terminal

This allows us to run `yarn test` from the root level of the repo to run all tests again. Percy still runs in CI, but via its own command.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
