### PR TITLE
[WF-182] use ButtonGroup to position buttons in AlertDialog

### DIFF
--- a/packages/react-components/modals/src/AlertDialog/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/AlertDialog/__snapshots__/index.spec.tsx.snap
@@ -159,6 +159,8 @@ exports[`<AlertModal /> isOpen renders the modal via a portal when true 1`] = `
 }
 
 .emotion-7 {
+  display: inline-block;
+  white-space: nowrap;
   margin-top: 24px;
 }
 
@@ -188,7 +190,7 @@ exports[`<AlertModal /> isOpen renders the modal via a portal when true 1`] = `
   background-color: white;
   box-shadow: inset 0 0 0 1px #33aacc;
   padding: 0 16px;
-  margin-right: 16px;
+  margin-left: 0;
 }
 
 .emotion-4:active {
@@ -268,6 +270,7 @@ exports[`<AlertModal /> isOpen renders the modal via a portal when true 1`] = `
   white-space: nowrap;
   background-color: #33aacc;
   padding: 0 16px;
+  margin-left: 16px;
 }
 
 .emotion-6:active {

--- a/packages/react-components/modals/src/AlertDialog/index.tsx
+++ b/packages/react-components/modals/src/AlertDialog/index.tsx
@@ -1,4 +1,4 @@
-import Button from '@datacamp/waffles-button';
+import Button, { ButtonGroup } from '@datacamp/waffles-button';
 import { Heading, Paragraph } from '@datacamp/waffles-text';
 import { css } from '@emotion/core';
 import React, { createRef } from 'react';
@@ -65,10 +65,9 @@ const AlertDialog: React.FC<AlertModalProps> = ({
           {title}
         </Heading>
         <Paragraph>{description}</Paragraph>
-        <div css={{ marginTop: 24 }}>
+        <ButtonGroup css={{ marginTop: 24 }}>
           <Button
             ref={cancelButtonRef}
-            css={{ marginRight: 16 }}
             disabled={isLoading}
             onClick={onCancelButton}
           >
@@ -83,7 +82,7 @@ const AlertDialog: React.FC<AlertModalProps> = ({
           >
             {confirmButtonText}
           </Button>
-        </div>
+        </ButtonGroup>
       </div>
     </BaseDialog>
   );


### PR DESCRIPTION
## Proposed changes
Percy shows no visual difference. This is purely a refactor to make use of the ButtonGroup rather than adding custom style to the AlertDialog.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
