### PR TITLE
[WF-192] add @emotion/core as a peer dependency

### DIFF
--- a/packages/react-components/button/package.json
+++ b/packages/react-components/button/package.json
@@ -33,6 +33,7 @@
     "@datacamp/waffles-babel-preset": "^1.2.6",
     "@datacamp/waffles-icons": "^1.6.0",
     "@datacamp/waffles-tsconfig": "^1.1.3",
+    "@emotion/core": "^10.0.17",
     "@testing-library/jest-dom": "4.1.0",
     "@testing-library/react": "8.0.7",
     "@testing-library/user-event": "7.0.1",
@@ -49,13 +50,13 @@
     "@datacamp/waffles-text": "^0.12.6",
     "@datacamp/waffles-tokens": "^0.6.4",
     "@datacamp/waffles-utils": "^1.1.4",
-    "@emotion/core": "^10.0.17",
     "airbnb-prop-types": "^2.15.0",
     "lodash": "^4.17.13",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "@datacamp/waffles-icons": "^1.3.3",
+    "@emotion/core": "^10.0.17",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },

--- a/packages/react-components/card/package.json
+++ b/packages/react-components/card/package.json
@@ -31,6 +31,7 @@
     "@datacamp/waffles-axe-render": "^1.1.3",
     "@datacamp/waffles-babel-preset": "^1.2.6",
     "@datacamp/waffles-tsconfig": "^1.1.3",
+    "@emotion/core": "^10.0.17",
     "@testing-library/jest-dom": "4.1.0",
     "@testing-library/react": "8.0.7",
     "@types/jest": "24.0.18",
@@ -44,11 +45,11 @@
   "dependencies": {
     "@babel/runtime": "^7.6.0",
     "@datacamp/waffles-tokens": "^0.6.4",
-    "@emotion/core": "^10.0.17",
     "lodash": "^4.17.13",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
+    "@emotion/core": "^10.0.17",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/packages/react-components/form-elements/package.json
+++ b/packages/react-components/form-elements/package.json
@@ -30,6 +30,7 @@
     "@datacamp/waffles-axe-render": "^1.1.3",
     "@datacamp/waffles-babel-preset": "^1.2.6",
     "@datacamp/waffles-tsconfig": "^1.1.3",
+    "@emotion/core": "^10.0.17",
     "@testing-library/jest-dom": "4.1.0",
     "@testing-library/react": "8.0.7",
     "@testing-library/user-event": "7.0.1",
@@ -47,11 +48,11 @@
     "@datacamp/waffles-text": "^0.12.6",
     "@datacamp/waffles-tokens": "^0.6.4",
     "@datacamp/waffles-utils": "^1.1.4",
-    "@emotion/core": "^10.0.17",
     "lodash": "^4.17.13",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
+    "@emotion/core": "^10.0.17",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/packages/react-components/markdown/package.json
+++ b/packages/react-components/markdown/package.json
@@ -48,6 +48,7 @@
     "react-markdown": "^4.2.2"
   },
   "peerDependencies": {
+    "@emotion/core": "^10.0.17",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/packages/react-components/modals/package.json
+++ b/packages/react-components/modals/package.json
@@ -30,6 +30,7 @@
     "@datacamp/waffles-axe-render": "^1.1.3",
     "@datacamp/waffles-babel-preset": "^1.2.6",
     "@datacamp/waffles-tsconfig": "^1.1.3",
+    "@emotion/core": "^10.0.17",
     "@testing-library/jest-dom": "4.1.0",
     "@testing-library/react": "8.0.7",
     "@testing-library/user-event": "7.0.1",
@@ -49,7 +50,6 @@
     "@datacamp/waffles-icons": "^1.6.0",
     "@datacamp/waffles-text": "^0.12.6",
     "@datacamp/waffles-tokens": "^0.6.4",
-    "@emotion/core": "^10.0.17",
     "@types/react-modal": "^3.8.3",
     "airbnb-prop-types": "^2.15.0",
     "lodash": "^4.17.13",
@@ -58,6 +58,7 @@
     "tinycolor2": "^1.4.1"
   },
   "peerDependencies": {
+    "@emotion/core": "^10.0.17",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }

--- a/packages/react-components/tag/package.json
+++ b/packages/react-components/tag/package.json
@@ -36,6 +36,7 @@
     "@datacamp/waffles-axe-render": "^1.1.3",
     "@datacamp/waffles-babel-preset": "^1.2.6",
     "@datacamp/waffles-tsconfig": "^1.1.3",
+    "@emotion/core": "^10.0.17",
     "@testing-library/jest-dom": "4.1.0",
     "@testing-library/react": "8.0.7",
     "@types/enzyme": "^3.10.3",
@@ -55,11 +56,11 @@
     "@datacamp/waffles-core": "^1.2.13",
     "@datacamp/waffles-text": "^0.12.6",
     "@datacamp/waffles-tokens": "^0.6.4",
-    "@emotion/core": "^10.0.17",
     "lodash": "^4.17.13",
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
+    "@emotion/core": "^10.0.17",
     "react": ">= 16.6.3"
   },
   "publishConfig": {

--- a/packages/react-components/text/package.json
+++ b/packages/react-components/text/package.json
@@ -26,6 +26,7 @@
     "@datacamp/waffles-axe-render": "^1.1.3",
     "@datacamp/waffles-babel-preset": "^1.2.6",
     "@datacamp/waffles-tsconfig": "^1.1.3",
+    "@emotion/core": "^10.0.17",
     "@testing-library/jest-dom": "4.1.0",
     "@testing-library/react": "8.0.7",
     "@types/jest": "24.0.18",
@@ -40,12 +41,12 @@
     "@babel/runtime": "^7.6.0",
     "@datacamp/waffles-tokens": "^0.6.4",
     "@datacamp/waffles-utils": "^1.1.4",
-    "@emotion/core": "^10.0.17",
     "emotion": "^10.0.17",
     "lodash": "^4.17.13",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
+    "@emotion/core": "^10.0.17",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   }


### PR DESCRIPTION
BREAKING CHANGE: @emotion/core is now a peerDependency rather than a 
dependency. This is to ensure that only one version is used. This 
package now requires @emotion/core to be installed alongside it.

## Proposed changes
Spotted by @vvnkr our styles don't properly compose when multiple versions of emotion are present on the page.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
