### PR TITLE
[WF-251] remove icon button title and hide icon from screenreaders

### DIFF
--- a/packages/react-components/button/src/Button/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/button/src/Button/__snapshots__/index.spec.tsx.snap
@@ -10511,15 +10511,12 @@ exports[`<Button /> snapshots renders a squared button with a single icon 1`] = 
   type="button"
 >
   <svg
-    aria-hidden="false"
+    aria-hidden="true"
     height="18"
     role="img"
     viewBox="0 0 18 18"
     width="18"
   >
-    <title>
-      Add
-    </title>
     <path
       d="M9 16A7 7 0 1 0 9 2a7 7 0 0 0 0 14zm0 2A9 9 0 1 1 9 0a9 9 0 0 1 0 18zm1-10h3a1 1 0 0 1 0 2h-3v3a1 1 0 0 1-2 0v-3H5a1 1 0 1 1 0-2h3V5a1 1 0 1 1 2 0v3z"
       fill="currentColor"

--- a/packages/react-components/button/src/Button/index.spec.tsx
+++ b/packages/react-components/button/src/Button/index.spec.tsx
@@ -308,14 +308,14 @@ describe('<Button />', () => {
 
   describe('Single icon', () => {
     it('renders a single icon as a child', async () => {
-      const { container, getByTitle } = await axeRender(
+      const { container } = await axeRender(
         <Button ariaLabel="add" onClick={someFunction}>
           <AddCircleIcon />
         </Button>
       );
 
       const buttonElement = container.firstChild;
-      const iconElement = getByTitle('Add') as HTMLElement;
+      const iconElement = container.querySelector('svg');
       expect(buttonElement).toContainElement(iconElement);
     });
 
@@ -527,7 +527,7 @@ describe('<Button />', () => {
 
   describe('Icon and text', () => {
     it('renders an icon and a string as children', async () => {
-      const { container, getByText, getByTitle } = await axeRender(
+      const { container, getByText } = await axeRender(
         <Button onClick={someFunction}>
           TestText
           <AddCircleIcon />
@@ -535,7 +535,7 @@ describe('<Button />', () => {
       );
 
       const buttonElement = container.firstChild;
-      const iconElement = getByTitle('Add') as HTMLElement;
+      const iconElement = container.querySelector('svg');
       expect(buttonElement).toContainElement(iconElement);
       expect(buttonElement).toContainElement(getByText(
         'TestText'

--- a/packages/react-components/button/src/Button/index.tsx
+++ b/packages/react-components/button/src/Button/index.tsx
@@ -167,8 +167,10 @@ const Button: React.FC<ButtonProps & { innerRef?: React.Ref<any> }> = props => {
       );
     }
     return React.cloneElement(child, {
+      'aria-hidden': true, // hide icon from screen reader so only ariaLabel or button text is read.
       color: loading ? 'transparent' : getColor,
       size: size === 'large' ? 24 : 18,
+      title: '', // remove tooltip from icon within button
     });
   };
 


### PR DESCRIPTION
## Proposed changes
The icon title causes a funky tooltip when within a button, plus it will be announced by screen readers. Since we enforce an aria label or other text within  the button this should all be removed.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
