### PR TITLE
[WF-289] strip prop types from production builds

### DIFF
--- a/packages/tools/babel-preset/index.js
+++ b/packages/tools/babel-preset/index.js
@@ -7,6 +7,7 @@ const pluginTypescriptToProptypes = require('babel-plugin-typescript-to-proptype
   .default;
 const pluginTransformRuntime = require('@babel/plugin-transform-runtime');
 const pluginProposalClassProperties = require('@babel/plugin-proposal-class-properties');
+const pluginTransformReactRemovePropTypes = require('babel-plugin-transform-react-remove-prop-types');
 
 const targets = {
   browsers: ['last 2 versions', 'Firefox ESR', 'not IE < 11'],
@@ -41,6 +42,7 @@ module.exports = () => ({
     pluginLodash,
     pluginProposalClassProperties,
     pluginTypescriptToProptypes,
+    [pluginTransformReactRemovePropTypes, { mode: 'wrap' }], // must happen after typescript to proptypes conversion
     pluginTransformRuntime,
   ],
   presets: [[presetEnv], presetReact, presetTypescript, presetCSSProp],

--- a/packages/tools/babel-preset/package.json
+++ b/packages/tools/babel-preset/package.json
@@ -13,6 +13,7 @@
     "@babel/preset-typescript": "^7.8.3",
     "@emotion/babel-preset-css-prop": "^10.0.27",
     "babel-plugin-lodash": "^3.3.4",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "babel-plugin-typescript-to-proptypes": "^1.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5632,7 +5632,7 @@ babel-plugin-transform-react-jsx@6.24.1, babel-plugin-transform-react-jsx@^6.24.
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-react-remove-prop-types@0.4.24:
+babel-plugin-transform-react-remove-prop-types@0.4.24, babel-plugin-transform-react-remove-prop-types@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
   integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==


### PR DESCRIPTION
## Proposed changes
Jeroen noticed that by using the button component all the icons were making their way into the bundle. This fixes that 🎉 

Now proptypes are all wrapped in a check to see if it is a production build. This means that not only will they not be checked on production as before but they won't be included, allowing webpack to treeshake more effectively

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [x] Approved by Designer, Engineer, & PO
