### PR TITLE
[WF-288] add z-index to make toasts appear above modals

### DIFF
--- a/packages/react-components/toast/src/Toast.tsx
+++ b/packages/react-components/toast/src/Toast.tsx
@@ -53,6 +53,7 @@ const Toast = ({
         maxWidth: 512,
         minWidth: 250,
         position: 'relative',
+        zIndex: parseInt(tokens.zIndex[999].value, 10),
       })}
     >
       <div

--- a/packages/react-components/toast/src/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/toast/src/__snapshots__/index.spec.tsx.snap
@@ -20,6 +20,7 @@ exports[`toast mounts a success toast 1`] = `
   max-width: 512px;
   min-width: 250px;
   position: relative;
+  z-index: 999;
 }
 
 .emotion-0 {
@@ -167,6 +168,7 @@ exports[`toast mounts an error toast 1`] = `
   max-width: 512px;
   min-width: 250px;
   position: relative;
+  z-index: 999;
 }
 
 .emotion-1 {


### PR DESCRIPTION
## Proposed changes
Adds the "highest" z index to toasts so they always appear on top.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [x] Approved by Designer, Engineer, & PO
