### PR TITLE
WF-293 set z index of close button in modals

### DIFF
--- a/packages/react-components/modals/src/AlertDialog/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/AlertDialog/__snapshots__/index.spec.tsx.snap
@@ -86,6 +86,7 @@ exports[`<AlertModal /> isOpen renders the modal via a portal when true 1`] = `
   right: 8px;
   top: 8px;
   width: 32px;
+  z-index: 1;
 }
 
 .emotion-0:active {

--- a/packages/react-components/modals/src/Dialog/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/Dialog/__snapshots__/index.spec.tsx.snap
@@ -85,6 +85,7 @@ exports[`<Dialog /> isOpen renders the modal via a portal when true 1`] = `
   right: 8px;
   top: 8px;
   width: 32px;
+  z-index: 1;
 }
 
 .emotion-0:active {

--- a/packages/react-components/modals/src/Panel/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/Panel/__snapshots__/index.spec.tsx.snap
@@ -87,6 +87,7 @@ exports[`<Panel /> isOpen renders the modal via a portal when true 1`] = `
   right: 8px;
   top: 8px;
   width: 32px;
+  z-index: 1;
 }
 
 .emotion-0:active {

--- a/packages/react-components/modals/src/shared/CloseButton.tsx
+++ b/packages/react-components/modals/src/shared/CloseButton.tsx
@@ -33,6 +33,7 @@ const CloseButton: React.FC<{ disabled: boolean; onClick: () => void }> = ({
       right: tokens.size.space[8].value,
       top: tokens.size.space[8].value,
       width: tokens.size.space[32].value,
+      zIndex: 1,
     })}
     disabled={disabled}
     onClick={onClick}


### PR DESCRIPTION
## Proposed changes
Does what it says. Makes sure it hovers over any headings that are introduced by the consumer

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
