### PR TITLE
WF-308 remove dev files from bundled packages

### DIFF
--- a/packages/other/tokens/package.json
+++ b/packages/other/tokens/package.json
@@ -3,6 +3,9 @@
   "version": "0.6.9",
   "description": "",
   "main": "lib/core-tokens.json",
+  "files": [
+    "lib"
+  ],
   "homepage": "https://github.com/datacamp-engineering/design-system/tree/master/packages/other/tokens/README.md",
   "scripts": {
     "build": "yarn clean && node build.js",

--- a/packages/other/utils/package.json
+++ b/packages/other/utils/package.json
@@ -8,6 +8,11 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "types/index.d.ts",
+  "files": [
+    "es",
+    "lib",
+    "types"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/datacamp/design-system.git"

--- a/packages/react-components/button/package.json
+++ b/packages/react-components/button/package.json
@@ -11,6 +11,11 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "types/index.d.ts",
+  "files": [
+    "es",
+    "lib",
+    "types"
+  ],
   "scripts": {
     "build:cjs": "BABEL_ENV=cjs babel src --extensions '.tsx','.ts' --out-dir lib --ignore \"src/**/*.spec.tsx\",\"src/**/*.spec.ts\" --config-file ./babel7.config.js",
     "build:es": "BABEL_ENV=es babel src --extensions '.tsx','.ts' --out-dir es --ignore \"src/**/*.spec.tsx\",\"src/**/*.spec.ts\" --config-file ./babel7.config.js",

--- a/packages/react-components/card/package.json
+++ b/packages/react-components/card/package.json
@@ -5,6 +5,11 @@
   "module": "es/index.js",
   "types": "types/index.d.ts",
   "license": "UNLICENSED",
+  "files": [
+    "es",
+    "lib",
+    "types"
+  ],
   "sideEffects": [
     "lib/sideEffects/*",
     "es/sideEffects/*"

--- a/packages/react-components/form-elements/package.json
+++ b/packages/react-components/form-elements/package.json
@@ -4,6 +4,11 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "types/index.d.ts",
+  "files": [
+    "es",
+    "lib",
+    "types"
+  ],
   "license": "UNLICENSED",
   "sideEffects": [
     "lib/sideEffects/*",

--- a/packages/react-components/icons/package.json
+++ b/packages/react-components/icons/package.json
@@ -3,6 +3,12 @@
   "version": "1.9.3",
   "main": "lib/web/index.js",
   "module": "es/web/index.js",
+  "files": [
+    "es",
+    "lib",
+    "types",
+    "sprites"
+  ],
   "license": "ISC",
   "sideEffects": false,
   "repository": {

--- a/packages/react-components/markdown/package.json
+++ b/packages/react-components/markdown/package.json
@@ -4,6 +4,11 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "types/index.d.ts",
+  "files": [
+    "es",
+    "lib",
+    "types"
+  ],
   "license": "UNLICENSED",
   "sideEffects": [
     "lib/sideEffects/*",

--- a/packages/react-components/modals/package.json
+++ b/packages/react-components/modals/package.json
@@ -4,6 +4,11 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "types/index.d.ts",
+  "files": [
+    "es",
+    "lib",
+    "types"
+  ],
   "license": "UNLICENSED",
   "sideEffects": [
     "lib/sideEffects/*",

--- a/packages/react-components/positioner/package.json
+++ b/packages/react-components/positioner/package.json
@@ -11,6 +11,11 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "types/index.d.ts",
+  "files": [
+    "es",
+    "lib",
+    "types"
+  ],
   "scripts": {
     "build:cjs": "BABEL_ENV=cjs babel src --extensions '.tsx','.ts' --out-dir lib --ignore \"src/**/*.spec.tsx\",\"src/**/*.spec.ts\" --config-file ./babel7.config.js",
     "build:es": "BABEL_ENV=es babel src --extensions '.tsx','.ts' --out-dir es --ignore \"src/**/*.spec.tsx\",\"src/**/*.spec.ts\" --config-file ./babel7.config.js",

--- a/packages/react-components/tag/package.json
+++ b/packages/react-components/tag/package.json
@@ -5,6 +5,11 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "types/index.d.ts",
+  "files": [
+    "es",
+    "lib",
+    "types"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/datacamp-engineering/design-system/tree/master/packages/react-components/tag/"

--- a/packages/react-components/text/package.json
+++ b/packages/react-components/text/package.json
@@ -4,6 +4,11 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "types/index.d.ts",
+  "files": [
+    "es",
+    "lib",
+    "types"
+  ],
   "license": "UNLICENSED",
   "sideEffects": [
     "lib/sideEffects/*",

--- a/packages/react-components/toast/package.json
+++ b/packages/react-components/toast/package.json
@@ -10,6 +10,11 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "types/index.d.ts",
+  "files": [
+    "es",
+    "lib",
+    "types"
+  ],
   "scripts": {
     "build:cjs": "BABEL_ENV=cjs babel src --extensions '.tsx','.ts' --out-dir lib --ignore \"src/**/*.spec.tsx\",\"src/**/*.spec.ts\" --config-file ./babel7.config.js",
     "build:es": "BABEL_ENV=es babel src --extensions '.tsx','.ts' --out-dir es --ignore \"src/**/*.spec.tsx\",\"src/**/*.spec.ts\" --config-file ./babel7.config.js",


### PR DESCRIPTION
## Proposed changes
Bundled packages were getting pretty large, this wouldn't affect built applications since they should tree shake, but it causes issues with installs since the package on the repository got too big. This PR only puts the necessary transpiled files into the bundle.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
