### PR TITLE
chore: Move RN types to be a devDependency

### DIFF
--- a/packages/react-components/icons/package.json
+++ b/packages/react-components/icons/package.json
@@ -30,6 +30,7 @@
     "@svgr/plugin-prettier": "^5.0.1",
     "@svgr/plugin-svgo": "^5.2.0",
     "@types/react": "^16.9.9",
+    "@types/react-native": "^0.60.31",
     "camelcase": "^5.3.1",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
@@ -46,7 +47,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.9.2",
-    "@types/react-native": "^0.60.31",
     "prop-types": "^15.7.2",
     "react-native-svg": "^9.13.6"
   },


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to project maintainers, then
provide any implementation and technical details. Also please list any potential
problems or considerations and tag team members you'd like input from. -->

I noticed we had these in campus. Totally minor, but I assume they only need to be devDependency. Feel free to close the PR if they need to be a runtime dependency.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [ ] Unit tests written & pass CI
- [ ] Integration tests written & pass CI
- [ ] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [ ] Technical docs written
- [ ] Structural changes reflected in Readme
- [ ] Migration plan for breaking changes

## Meets Product Requirement

- [ ] Assumptions are met
- [ ] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
