### PR TITLE
WF-302 use waffles list components in documentation

### DIFF
--- a/packages/docs/catalog-doc-site/catalog/pages/componentLibrary/button.js
+++ b/packages/docs/catalog-doc-site/catalog/pages/componentLibrary/button.js
@@ -9,9 +9,9 @@ import {
   Code,
   CodeBlock,
   Heading,
+  List,
   Paragraph,
   Strong,
-  Text,
 } from '@datacamp/waffles-text';
 /* @jsx jsx */
 import { jsx } from '@emotion/core';
@@ -42,27 +42,21 @@ export default () => {
               Waffles exposes several components from within{' '}
               <Code>@datacamp/waffles-button</Code>.
             </Paragraph>
-            <ul>
-              <li>
-                <Text>
-                  <Strong>Button –</Strong> Able to have an icon on the left or
-                  right.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>ButtonGroup –</Strong> Enables you to layout several
-                  buttons of the same size with consistent spacing.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>CompactButtonGroup –</Strong> Enables you to
-                  concatenate multiple buttons into one. It can also be nested
-                  inside a <Code>ButtonGroup</Code>.
-                </Text>
-              </li>
-            </ul>
+            <List>
+              <List.Item>
+                <Strong>Button –</Strong> Able to have an icon on the left or
+                right.
+              </List.Item>
+              <List.Item>
+                <Strong>ButtonGroup –</Strong> Enables you to layout several
+                buttons of the same size with consistent spacing.
+              </List.Item>
+              <List.Item>
+                <Strong>CompactButtonGroup –</Strong> Enables you to concatenate
+                multiple buttons into one. It can also be nested inside a{' '}
+                <Code>ButtonGroup</Code>.
+              </List.Item>
+            </List>
             <CodeBlock>
               {
                 "import Button, { ButtonGroup, CompactButtonGroup } from '@datacamp/waffles-button';"

--- a/packages/docs/catalog-doc-site/catalog/pages/componentLibrary/formElements.js
+++ b/packages/docs/catalog-doc-site/catalog/pages/componentLibrary/formElements.js
@@ -11,9 +11,9 @@ import {
   Code,
   CodeBlock,
   Heading,
+  List,
   Paragraph,
   Strong,
-  Text,
 } from '@datacamp/waffles-text';
 /* @jsx jsx */
 import { jsx } from '@emotion/core';
@@ -43,38 +43,28 @@ export default () => {
               Waffles exposes several components from within{' '}
               <Code>@datacamp/waffles-form-elements</Code>.
             </Paragraph>
-            <ul>
-              <li>
-                <Text>
-                  <Strong>Input –</Strong> Able to handle multiple types of text
-                  input.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>Select –</Strong> Allows the user to select one from a
-                  list of options.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>SelectOption -</Strong> To be used within a{' '}
-                  <Code>Select</Code> to specify an available option.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>RadioList –</Strong> Allows the user to choose one
-                  from a list of options.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>Radio -</Strong> To be used within a{' '}
-                  <Code>RadioList</Code> to specify an available option.
-                </Text>
-              </li>
-            </ul>
+            <List>
+              <List.Item>
+                <Strong>Input –</Strong> Able to handle multiple types of text
+                input.
+              </List.Item>
+              <List.Item>
+                <Strong>Select –</Strong> Allows the user to select one from a
+                list of options.
+              </List.Item>
+              <List.Item>
+                <Strong>SelectOption -</Strong> To be used within a{' '}
+                <Code>Select</Code> to specify an available option.
+              </List.Item>
+              <List.Item>
+                <Strong>RadioList –</Strong> Allows the user to choose one from
+                a list of options.
+              </List.Item>
+              <List.Item>
+                <Strong>Radio -</Strong> To be used within a{' '}
+                <Code>RadioList</Code> to specify an available option.
+              </List.Item>
+            </List>
             <CodeBlock>
               {`import {
   Input,

--- a/packages/docs/catalog-doc-site/catalog/pages/componentLibrary/icons.js
+++ b/packages/docs/catalog-doc-site/catalog/pages/componentLibrary/icons.js
@@ -1,4 +1,5 @@
 import * as Icons from '@datacamp/waffles-icons';
+import { List } from '@datacamp/waffles-text';
 import { colors } from '@datacamp/waffles-tokens';
 import { Page } from 'catalog';
 import { chunk } from 'lodash';
@@ -150,33 +151,33 @@ export default () => {
               </a>
               . Feel free to use whichever makes most sense for your use case.
             </p>
-            <ul>
-              <li>
+            <List>
+              <List.Item>
                 <code>
                   @datacamp/waffles-icons/sprites/css/svg/sprite.css-bde2e71c.svg
                 </code>
-              </li>
-              <li>
+              </List.Item>
+              <List.Item>
                 <code>
                   @datacamp/waffles-icons/sprites/defs/svg/sprite.defs.svg
                 </code>
-              </li>
-              <li>
+              </List.Item>
+              <List.Item>
                 <code>
                   @datacamp/waffles-icons/sprites/stack/svg/sprite.stack.svg
                 </code>
-              </li>
-              <li>
+              </List.Item>
+              <List.Item>
                 <code>
                   @datacamp/waffles-icons/sprites/symbol/svg/sprite.symbol.svg
                 </code>
-              </li>
-              <li>
+              </List.Item>
+              <List.Item>
                 <code>
                   @datacamp/waffles-icons/sprites/view/svg/sprite.view-f796bea8.svg
                 </code>
-              </li>
-            </ul>
+              </List.Item>
+            </List>
           </div>
         </section>
       </Page>

--- a/packages/docs/catalog-doc-site/catalog/pages/componentLibrary/modals.js
+++ b/packages/docs/catalog-doc-site/catalog/pages/componentLibrary/modals.js
@@ -6,9 +6,9 @@ import {
   Code,
   CodeBlock,
   Heading,
+  List,
   Paragraph,
   Strong,
-  Text,
 } from '@datacamp/waffles-text';
 /* @jsx jsx */
 import { jsx } from '@emotion/core';
@@ -38,28 +38,21 @@ export default () => {
               Waffles exposes several components from within{' '}
               <Code>@datacamp/waffles-modals</Code>.
             </Paragraph>
-            <ul>
-              <li>
-                <Text>
-                  <Strong>AlertDialog –</Strong> Asks for confirmation before
-                  performing an action.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>Dialog –</Strong> Enables custom content to be
-                  displayed in a way that blocks interaction with the rest of
-                  the page.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>Panel –</Strong> Enables larger amounts of custom
-                  content to be displayed in a way that blocks interaction with
-                  the rest of the page.
-                </Text>
-              </li>
-            </ul>
+            <List>
+              <List.Item>
+                <Strong>AlertDialog –</Strong> Asks for confirmation before
+                performing an action.
+              </List.Item>
+              <List.Item>
+                <Strong>Dialog –</Strong> Enables custom content to be displayed
+                in a way that blocks interaction with the rest of the page.
+              </List.Item>
+              <List.Item>
+                <Strong>Panel –</Strong> Enables larger amounts of custom
+                content to be displayed in a way that blocks interaction with
+                the rest of the page.
+              </List.Item>
+            </List>
             <Paragraph>
               Before using any of these components, <Code>setAppElement</Code>{' '}
               should be called with the root element of the application. This

--- a/packages/docs/catalog-doc-site/catalog/pages/componentLibrary/text.js
+++ b/packages/docs/catalog-doc-site/catalog/pages/componentLibrary/text.js
@@ -43,82 +43,55 @@ export default () => {
               Waffles exposes several components from the{' '}
               <Code>@datacamp/waffles-text</Code> package.
             </Paragraph>
-            <ul>
-              <li>
-                <Text>
-                  <Strong>GlobalFontFaces –</Strong> A global component that
-                  loads the font faces used by the other components. If the
-                  waffles scss is not being used, this component should be
-                  mounted on the page.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>Text –</Strong> The base text component that can be
-                  used as a building block for everthing else.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>Paragraph –</Strong> Renders a block of text.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>Heading –</Strong> Renders various sized headings.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>Strong –</Strong> Renders bold text.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>Emphasis –</Strong> Renders italic text.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>Small –</Strong> Renders text at a size smaller than
-                  the default.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>Code –</Strong> Renders inline code.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>CodeBlock –</Strong> Renders a preformatted block of
-                  code.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>Link –</Strong> Renders an anchor component.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>Badge –</Strong> Renders a coloured badge.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>BetaBadge –</Strong> A specific version of the Badge
-                  component used to signify and product or feature is in Beta.
-                  It has a a fixed colour and size.
-                </Text>
-              </li>
-              <li>
-                <Text>
-                  <Strong>List –</Strong> Renders either an ordered or unordered
-                  list.
-                </Text>
-              </li>
-            </ul>
+            <List>
+              <List.Item>
+                <Strong>GlobalFontFaces –</Strong> A global component that loads
+                the font faces used by the other components. If the waffles scss
+                is not being used, this component should be mounted on the page.
+              </List.Item>
+              <List.Item>
+                <Strong>Text –</Strong> The base text component that can be used
+                as a building block for everthing else.
+              </List.Item>
+              <List.Item>
+                <Strong>Paragraph –</Strong> Renders a block of text.
+              </List.Item>
+              <List.Item>
+                <Strong>Heading –</Strong> Renders various sized headings.
+              </List.Item>
+              <List.Item>
+                <Strong>Strong –</Strong> Renders bold text.
+              </List.Item>
+              <List.Item>
+                <Strong>Emphasis –</Strong> Renders italic text.
+              </List.Item>
+              <List.Item>
+                <Strong>Small –</Strong> Renders text at a size smaller than the
+                default.
+              </List.Item>
+              <List.Item>
+                <Strong>Code –</Strong> Renders inline code.
+              </List.Item>
+              <List.Item>
+                <Strong>CodeBlock –</Strong> Renders a preformatted block of
+                code.
+              </List.Item>
+              <List.Item>
+                <Strong>Link –</Strong> Renders an anchor component.
+              </List.Item>
+              <List.Item>
+                <Strong>Badge –</Strong> Renders a coloured badge.
+              </List.Item>
+              <List.Item>
+                <Strong>BetaBadge –</Strong> A specific version of the Badge
+                component used to signify and product or feature is in Beta. It
+                has a a fixed colour and size.
+              </List.Item>
+              <List.Item>
+                <Strong>List –</Strong> Renders either an ordered or unordered
+                list.
+              </List.Item>
+            </List>
             <CodeBlock>
               {`import {
   Badge,


### PR DESCRIPTION
## Proposed changes
Swaps out the old bullet lists for the shiny new waffles version (looks identical)

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
