### PR TITLE
WF-316 remove stuck tooltip when disabling button

### DIFF
--- a/packages/react-components/button/src/Button/index.tsx
+++ b/packages/react-components/button/src/Button/index.tsx
@@ -5,7 +5,13 @@ import { computeDataAttributes } from '@datacamp/waffles-utils';
 import { css, SerializedStyles } from '@emotion/core';
 import { childrenOfType, nChildren } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
-import React, { ComponentProps, ReactElement, useRef, useState } from 'react';
+import React, {
+  ComponentProps,
+  ReactElement,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useUIDSeed } from 'react-uid';
 import { mergeRefs } from 'use-callback-ref';
 
@@ -149,6 +155,14 @@ const InternalButton = (
   const buttonRef = useRef<HTMLElement>();
   const [hasFocus, setHasFocus] = useState(false);
   const [hasHover, setHasHover] = useState(false);
+
+  // remove hover state when disabling a button
+  useEffect(() => {
+    if (loading || disabled) {
+      setHasHover(false);
+    }
+  }, [loading, disabled]);
+
   const uidSeed = useUIDSeed();
   const tooltipId = uidSeed('button-tooltip');
   const outlineTextColor = tokens.color.opaque.greyDark.value.hex;


### PR DESCRIPTION
## Proposed changes
Clears the hover state when a button disables. Stops it getting stuck

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
