### PR TITLE
[WF-340] add optional onClick to buttons with type="link"

### DIFF
--- a/packages/react-components/button/src/Button/index.tsx
+++ b/packages/react-components/button/src/Button/index.tsx
@@ -84,6 +84,7 @@ interface BaseButtonProps {
 
 interface LinkButtonProps {
   href: string;
+  onClick?: () => void;
   target?: '_blank' | undefined;
   type: 'link';
 }
@@ -206,6 +207,7 @@ const InternalButton = (
         return {
           Element: 'a',
           href: props.href,
+          onClick: props.onClick,
           target: props.target,
         } as const;
       case 'submit':


### PR DESCRIPTION
## Proposed changes
What it says on the tin. Still needs an href, but optionally also adds an onClick to make things nicer for client side navigation

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
