### PR TITLE
fix: load fonts from standard files

### DIFF
--- a/packages/react-components/text/src/fontFaces/regular.ts
+++ b/packages/react-components/text/src/fontFaces/regular.ts
@@ -1,11 +1,27 @@
+// When editing this file don't forget to also update the font faces in the core package
+
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
 import { css } from '@emotion/core';
 
-export default css({
-  '@font-face': {
-    fontFamily: tokens.asset.font.sansSerif.value,
-    fontWeight: '100 900' as any,
-    src:
-      "url('https://waffles.datacamp.com/fonts/studio-feixen-sans-variable.ttf') format('truetype')",
-  },
-});
+export default css`
+  @font-face {
+    font-family: ${tokens.asset.font.sansSerif.value};
+    src: url('https://waffles.datacamp.com/fonts/StudioFeixenSans-Medium.ttf')
+      format('truetype');
+    font-weight: ${tokens.fontWeight.regular.value};
+  }
+
+  @font-face {
+    font-family: ${tokens.asset.font.sansSerif.value};
+    src: url('https://waffles.datacamp.com/fonts/StudioFeixenSans-Bold.ttf')
+      format('truetype');
+    font-weight: ${tokens.fontWeight.bold.value};
+  }
+
+  @font-face {
+    font-family: ${tokens.asset.font.sansSerif.value};
+    src: url('https://waffles.datacamp.com/fonts/StudioFeixenSans-Book.ttf')
+      format('truetype');
+    font-weight: ${tokens.fontWeight.light.value};
+  }
+`;


### PR DESCRIPTION
## Proposed changes
Does the same font loading fix as was already applied to core. Doesn't use the variable fonts, still just and unoptimised ttf without swaps etc
