### PR TITLE
WF-363 SCSS Dropdown

### DIFF
--- a/packages/stylesheets/dropdown/lib/_dropdown.scss
+++ b/packages/stylesheets/dropdown/lib/_dropdown.scss
@@ -138,7 +138,7 @@
   width: 100%;
 
   @include afh {
-    background-color: $dc-beige-100;
+    background-color: $dc-grey-200;
     color: $dc-navy-text;
     cursor: pointer;
   }
@@ -233,7 +233,7 @@
   transition: background-color $dc-transition, color $dc-transition;
 
   @include state {
-    background-color: $dc-beige-100;
+    background-color: $dc-grey-200;
     border-color: transparent;
     color: $dc-navy-text;
   }


### PR DESCRIPTION
Updates the scss dropdown colours to match the new design. Some of this was already done, but now the hover colours matches that of the close button in the modal, toast etc.