### PR TITLE
WF-410 Inverted & Disabled neutral buttons

### DIFF
--- a/packages/react-components/button/src/Button/buttonStyles.ts
+++ b/packages/react-components/button/src/Button/buttonStyles.ts
@@ -158,6 +158,10 @@ const getDisabledStyle = (
       backgroundColor: baseColors[intent],
       borderColor: baseColors[intent],
     },
+    appearance === 'inverted' &&
+      intent === 'neutral' && {
+        borderColor: 'white',
+      },
   );
 
 export {


### PR DESCRIPTION
## Proposed changes
Neutral buttons are not the same colour when changing between inverted and default appearances. I'd forgotten to apply this override when the button was disabled.