### PR TITLE
WF-428 enable number inputs work

### DIFF
--- a/packages/react-components/form-elements/src/Input/index.tsx
+++ b/packages/react-components/form-elements/src/Input/index.tsx
@@ -153,6 +153,9 @@ const InternalInput = ({
   value,
   innerRef,
   type = 'text',
+  max,
+  min,
+  step,
 }: InputProps & { innerRef?: Ref<HTMLInputElement> }): ReactElement => {
   const parsedDataAttributes = computeDataAttributes(dataAttributes);
 
@@ -202,13 +205,16 @@ const InternalInput = ({
         css={getInputStyle}
         disabled={disabled}
         id={id}
+        max={max}
         maxLength={maxLength}
+        min={min}
         name={name}
         onBlur={handleBlur}
         onChange={handleChange}
         placeholder={placeholder}
         ref={innerRef}
         required={htmlRequired}
+        step={step}
         type={type}
         value={value}
         {...parsedDataAttributes}


### PR DESCRIPTION
## Proposed changes

It is hard to use number inputs with native browser validation because of the way some props are typed. This should resolve the typing issues.

## Functional Code

- [ ] Builds without errors
- [ ] Linter passes CI
- [ ] Unit tests written & pass CI
- [ ] Integration tests written & pass CI
- [ ] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [ ] Technical docs written
- [ ] Structural changes reflected in Readme
- [ ] Migration plan for breaking changes

## Meets Product Requirement

- [ ] Assumptions are met
- [ ] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
