### PR TITLE
WF-429 correct the fallback font implementation when in react

### DIFF
--- a/packages/react-components/button/src/Button/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/button/src/Button/__snapshots__/index.spec.tsx.snap
@@ -4,8 +4,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent d
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -167,8 +166,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent d
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -384,8 +382,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent d
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -547,8 +544,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent d
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -764,8 +760,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent d
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -927,8 +922,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent d
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1200,8 +1194,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent n
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1370,8 +1363,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent n
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1580,8 +1572,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent n
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1750,8 +1741,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent n
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1960,8 +1950,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent n
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2130,8 +2119,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent n
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2284,8 +2272,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent s
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2447,8 +2434,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent s
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2664,8 +2650,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent s
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2827,8 +2812,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent s
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3044,8 +3028,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent s
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3207,8 +3190,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent s
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3424,8 +3406,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent w
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3587,8 +3568,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent w
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3804,8 +3784,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent w
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3967,8 +3946,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent w
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -4184,8 +4162,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent w
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -4347,8 +4324,7 @@ exports[`<Button /> snapshots renders a button with appearance default, intent w
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -4564,8 +4540,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -4727,8 +4702,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -4944,8 +4918,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -5107,8 +5080,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -5324,8 +5296,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -5487,8 +5458,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -5760,8 +5730,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -5867,8 +5836,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -6084,8 +6052,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -6247,8 +6214,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -6520,8 +6486,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -6627,8 +6592,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -6844,8 +6808,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -7005,8 +6968,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -7222,8 +7184,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -7383,8 +7344,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -7600,8 +7560,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -7761,8 +7720,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -8034,8 +7992,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -8141,8 +8098,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -8358,8 +8314,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -8521,8 +8476,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -8794,8 +8748,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -8901,8 +8854,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -9174,8 +9126,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -9281,8 +9232,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -9498,8 +9448,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -9661,8 +9610,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -9934,8 +9882,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -10041,8 +9988,7 @@ exports[`<Button /> snapshots renders a button with appearance inverted, intent 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -10258,8 +10204,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent b
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -10427,8 +10372,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent b
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -10645,8 +10589,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent b
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -10814,8 +10757,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent b
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -11032,8 +10974,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent b
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -11201,8 +11142,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent b
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -11419,8 +11359,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent d
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -11588,8 +11527,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent d
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -11806,8 +11744,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent d
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -11975,8 +11912,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent d
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -12193,8 +12129,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent d
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -12362,8 +12297,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent d
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -12642,8 +12576,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent n
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -12749,8 +12682,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent n
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -13029,8 +12961,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent n
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -13136,8 +13067,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent n
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -13416,8 +13346,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent n
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -13523,8 +13452,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent n
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -13741,8 +13669,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent s
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -13910,8 +13837,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent s
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -14128,8 +14054,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent s
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -14297,8 +14222,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent s
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -14515,8 +14439,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent s
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -14684,8 +14607,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent s
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -14902,8 +14824,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent w
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -15071,8 +14992,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent w
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -15289,8 +15209,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent w
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -15458,8 +15377,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent w
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -15676,8 +15594,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent w
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -15845,8 +15762,7 @@ exports[`<Button /> snapshots renders a button with appearance primary, intent w
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -16197,8 +16113,7 @@ exports[`<Button /> tooltips tooltip appearance snapshots renders a tooltip with
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -16238,8 +16153,7 @@ exports[`<Button /> tooltips tooltip appearance snapshots renders a tooltip with
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -16340,8 +16254,7 @@ exports[`<Button /> tooltips tooltip appearance snapshots renders a tooltip with
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -16380,8 +16293,7 @@ exports[`<Button /> tooltips tooltip appearance snapshots renders a tooltip with
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -16482,8 +16394,7 @@ exports[`<Button /> tooltips tooltip appearance snapshots renders a tooltip with
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -16523,8 +16434,7 @@ exports[`<Button /> tooltips tooltip appearance snapshots renders a tooltip with
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -16625,8 +16535,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at b
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -16666,8 +16575,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at b
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -16768,8 +16676,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at b
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -16783,8 +16690,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at b
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -16908,8 +16814,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at b
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -16923,8 +16828,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at b
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -17051,8 +16955,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at l
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -17066,8 +16969,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at l
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -17194,8 +17096,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at r
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -17209,8 +17110,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at r
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -17337,8 +17237,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at t
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -17352,8 +17251,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at t
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -17480,8 +17378,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at t
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -17495,8 +17392,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at t
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -17623,8 +17519,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at t
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -17638,8 +17533,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at t
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -17766,8 +17660,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at u
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -17807,8 +17700,7 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at u
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;

--- a/packages/react-components/button/src/ButtonGroup/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/button/src/ButtonGroup/__snapshots__/index.spec.tsx.snap
@@ -69,8 +69,7 @@ exports[`ButtonGroup renders the buttons or CompactButtonGroups with 16px spaces
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -550,8 +549,7 @@ exports[`ButtonGroup renders the small buttons or CompactButtonGroups with 8px s
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;

--- a/packages/react-components/button/src/CompactButtonGroup/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/button/src/CompactButtonGroup/__snapshots__/index.spec.tsx.snap
@@ -80,8 +80,7 @@ exports[`CompactButtonGroup renders the buttons next to each other 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;

--- a/packages/react-components/form-elements/src/CheckboxList/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/form-elements/src/CheckboxList/__snapshots__/index.spec.tsx.snap
@@ -40,8 +40,7 @@ exports[`<CheckboxList> snapshots renders a checkbox list 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -79,8 +78,7 @@ exports[`<CheckboxList> snapshots renders a checkbox list 1`] = `
 .emotion-5 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -132,8 +130,7 @@ exports[`<CheckboxList> snapshots renders a checkbox list 1`] = `
 .emotion-15 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -147,8 +144,7 @@ exports[`<CheckboxList> snapshots renders a checkbox list 1`] = `
 .emotion-13 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;

--- a/packages/react-components/form-elements/src/Input/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/form-elements/src/Input/__snapshots__/index.spec.tsx.snap
@@ -40,8 +40,7 @@ exports[`snapshots renders an input with size large, disabled=false, required=fa
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -61,8 +60,7 @@ exports[`snapshots renders an input with size large, disabled=false, required=fa
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -83,8 +81,7 @@ exports[`snapshots renders an input with size large, disabled=false, required=fa
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -226,8 +223,7 @@ exports[`snapshots renders an input with size large, disabled=false, required=tr
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -247,8 +243,7 @@ exports[`snapshots renders an input with size large, disabled=false, required=tr
 .emotion-7 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -269,8 +264,7 @@ exports[`snapshots renders an input with size large, disabled=false, required=tr
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -282,8 +276,7 @@ exports[`snapshots renders an input with size large, disabled=false, required=tr
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -430,8 +423,7 @@ exports[`snapshots renders an input with size large, disabled=false, required=un
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -451,8 +443,7 @@ exports[`snapshots renders an input with size large, disabled=false, required=un
 .emotion-4 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -586,8 +577,7 @@ exports[`snapshots renders an input with size large, disabled=true, required=fal
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -607,8 +597,7 @@ exports[`snapshots renders an input with size large, disabled=true, required=fal
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -629,8 +618,7 @@ exports[`snapshots renders an input with size large, disabled=true, required=fal
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -773,8 +761,7 @@ exports[`snapshots renders an input with size large, disabled=true, required=tru
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -794,8 +781,7 @@ exports[`snapshots renders an input with size large, disabled=true, required=tru
 .emotion-7 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -816,8 +802,7 @@ exports[`snapshots renders an input with size large, disabled=true, required=tru
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -829,8 +814,7 @@ exports[`snapshots renders an input with size large, disabled=true, required=tru
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -978,8 +962,7 @@ exports[`snapshots renders an input with size large, disabled=true, required=und
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -999,8 +982,7 @@ exports[`snapshots renders an input with size large, disabled=true, required=und
 .emotion-4 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1135,8 +1117,7 @@ exports[`snapshots renders an input with size medium, disabled=false, required=f
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1208,8 +1189,7 @@ exports[`snapshots renders an input with size medium, disabled=false, required=f
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1230,8 +1210,7 @@ exports[`snapshots renders an input with size medium, disabled=false, required=f
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1321,8 +1300,7 @@ exports[`snapshots renders an input with size medium, disabled=false, required=t
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1394,8 +1372,7 @@ exports[`snapshots renders an input with size medium, disabled=false, required=t
 .emotion-7 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1416,8 +1393,7 @@ exports[`snapshots renders an input with size medium, disabled=false, required=t
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1429,8 +1405,7 @@ exports[`snapshots renders an input with size medium, disabled=false, required=t
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1525,8 +1500,7 @@ exports[`snapshots renders an input with size medium, disabled=false, required=u
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1598,8 +1572,7 @@ exports[`snapshots renders an input with size medium, disabled=false, required=u
 .emotion-4 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1681,8 +1654,7 @@ exports[`snapshots renders an input with size medium, disabled=true, required=fa
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1754,8 +1726,7 @@ exports[`snapshots renders an input with size medium, disabled=true, required=fa
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1776,8 +1747,7 @@ exports[`snapshots renders an input with size medium, disabled=true, required=fa
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1868,8 +1838,7 @@ exports[`snapshots renders an input with size medium, disabled=true, required=tr
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1941,8 +1910,7 @@ exports[`snapshots renders an input with size medium, disabled=true, required=tr
 .emotion-7 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1963,8 +1931,7 @@ exports[`snapshots renders an input with size medium, disabled=true, required=tr
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1976,8 +1943,7 @@ exports[`snapshots renders an input with size medium, disabled=true, required=tr
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2073,8 +2039,7 @@ exports[`snapshots renders an input with size medium, disabled=true, required=un
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2146,8 +2111,7 @@ exports[`snapshots renders an input with size medium, disabled=true, required=un
 .emotion-4 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2230,8 +2194,7 @@ exports[`snapshots renders an input with size small, disabled=false, required=fa
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2251,8 +2214,7 @@ exports[`snapshots renders an input with size small, disabled=false, required=fa
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2273,8 +2235,7 @@ exports[`snapshots renders an input with size small, disabled=false, required=fa
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2416,8 +2377,7 @@ exports[`snapshots renders an input with size small, disabled=false, required=tr
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2437,8 +2397,7 @@ exports[`snapshots renders an input with size small, disabled=false, required=tr
 .emotion-7 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2459,8 +2418,7 @@ exports[`snapshots renders an input with size small, disabled=false, required=tr
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2472,8 +2430,7 @@ exports[`snapshots renders an input with size small, disabled=false, required=tr
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2620,8 +2577,7 @@ exports[`snapshots renders an input with size small, disabled=false, required=un
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2641,8 +2597,7 @@ exports[`snapshots renders an input with size small, disabled=false, required=un
 .emotion-4 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2776,8 +2731,7 @@ exports[`snapshots renders an input with size small, disabled=true, required=fal
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2797,8 +2751,7 @@ exports[`snapshots renders an input with size small, disabled=true, required=fal
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2819,8 +2772,7 @@ exports[`snapshots renders an input with size small, disabled=true, required=fal
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2963,8 +2915,7 @@ exports[`snapshots renders an input with size small, disabled=true, required=tru
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2984,8 +2935,7 @@ exports[`snapshots renders an input with size small, disabled=true, required=tru
 .emotion-7 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3006,8 +2956,7 @@ exports[`snapshots renders an input with size small, disabled=true, required=tru
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3019,8 +2968,7 @@ exports[`snapshots renders an input with size small, disabled=true, required=tru
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3168,8 +3116,7 @@ exports[`snapshots renders an input with size small, disabled=true, required=und
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3189,8 +3136,7 @@ exports[`snapshots renders an input with size small, disabled=true, required=und
 .emotion-4 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;

--- a/packages/react-components/form-elements/src/RadioList/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/form-elements/src/RadioList/__snapshots__/index.spec.tsx.snap
@@ -40,8 +40,7 @@ exports[`<RadioList> snapshots renders a radio list 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -79,8 +78,7 @@ exports[`<RadioList> snapshots renders a radio list 1`] = `
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -128,8 +126,7 @@ exports[`<RadioList> snapshots renders a radio list 1`] = `
 .emotion-16 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -143,8 +140,7 @@ exports[`<RadioList> snapshots renders a radio list 1`] = `
 .emotion-14 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;

--- a/packages/react-components/form-elements/src/Select/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/form-elements/src/Select/__snapshots__/index.spec.tsx.snap
@@ -44,8 +44,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -73,8 +72,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-8 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -95,8 +93,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -265,8 +262,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -294,8 +290,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-9 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -316,8 +311,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -329,8 +323,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -504,8 +497,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -533,8 +525,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -695,8 +686,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -716,8 +706,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-8 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -738,8 +727,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -917,8 +905,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -938,8 +925,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-9 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -960,8 +946,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -973,8 +958,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1157,8 +1141,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1178,8 +1161,7 @@ exports[`with label snapshots renders a select element with size large, disabled
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1357,8 +1339,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1417,8 +1398,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-8 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1439,8 +1419,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1578,8 +1557,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1638,8 +1616,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-9 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1660,8 +1637,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1673,8 +1649,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1817,8 +1792,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1877,8 +1851,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2000,8 +1973,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2068,8 +2040,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-8 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2090,8 +2061,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2222,8 +2192,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2290,8 +2259,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-9 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2312,8 +2280,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2325,8 +2292,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2462,8 +2428,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2530,8 +2495,7 @@ exports[`with label snapshots renders a select element with size medium, disable
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2654,8 +2618,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2683,8 +2646,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-8 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2705,8 +2667,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2875,8 +2836,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2904,8 +2864,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-9 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2926,8 +2885,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -2939,8 +2897,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3114,8 +3071,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3143,8 +3099,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3305,8 +3260,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3326,8 +3280,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-8 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3348,8 +3301,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3527,8 +3479,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3548,8 +3499,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-9 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3570,8 +3520,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3583,8 +3532,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3767,8 +3715,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -3788,8 +3735,7 @@ exports[`with label snapshots renders a select element with size small, disabled
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;

--- a/packages/react-components/form-elements/src/TextArea/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/form-elements/src/TextArea/__snapshots__/index.spec.tsx.snap
@@ -40,8 +40,7 @@ exports[`snapshots renders an input with size disabled=false, required=false 1`]
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -115,8 +114,7 @@ exports[`snapshots renders an input with size disabled=false, required=false 1`]
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -137,8 +135,7 @@ exports[`snapshots renders an input with size disabled=false, required=false 1`]
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -227,8 +224,7 @@ exports[`snapshots renders an input with size disabled=false, required=true 1`] 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -302,8 +298,7 @@ exports[`snapshots renders an input with size disabled=false, required=true 1`] 
 .emotion-7 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -324,8 +319,7 @@ exports[`snapshots renders an input with size disabled=false, required=true 1`] 
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -337,8 +331,7 @@ exports[`snapshots renders an input with size disabled=false, required=true 1`] 
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -432,8 +425,7 @@ exports[`snapshots renders an input with size disabled=false, required=undefined
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -507,8 +499,7 @@ exports[`snapshots renders an input with size disabled=false, required=undefined
 .emotion-4 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -589,8 +580,7 @@ exports[`snapshots renders an input with size disabled=true, required=false 1`] 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -664,8 +654,7 @@ exports[`snapshots renders an input with size disabled=true, required=false 1`] 
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -686,8 +675,7 @@ exports[`snapshots renders an input with size disabled=true, required=false 1`] 
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -777,8 +765,7 @@ exports[`snapshots renders an input with size disabled=true, required=true 1`] =
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -852,8 +839,7 @@ exports[`snapshots renders an input with size disabled=true, required=true 1`] =
 .emotion-7 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -874,8 +860,7 @@ exports[`snapshots renders an input with size disabled=true, required=true 1`] =
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -887,8 +872,7 @@ exports[`snapshots renders an input with size disabled=true, required=true 1`] =
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -983,8 +967,7 @@ exports[`snapshots renders an input with size disabled=true, required=undefined 
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -1058,8 +1041,7 @@ exports[`snapshots renders an input with size disabled=true, required=undefined 
 .emotion-4 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;

--- a/packages/react-components/markdown/src/components/__snapshots__/Markdown.spec.tsx.snap
+++ b/packages/react-components/markdown/src/components/__snapshots__/Markdown.spec.tsx.snap
@@ -4,8 +4,7 @@ exports[`<Markdown /> renders 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -28,8 +27,7 @@ exports[`<Markdown /> renders 1`] = `
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -52,8 +50,7 @@ exports[`<Markdown /> renders 1`] = `
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -76,8 +73,7 @@ exports[`<Markdown /> renders 1`] = `
 .emotion-3 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -100,8 +96,7 @@ exports[`<Markdown /> renders 1`] = `
 .emotion-4 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -124,8 +119,7 @@ exports[`<Markdown /> renders 1`] = `
 .emotion-5 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -148,8 +142,7 @@ exports[`<Markdown /> renders 1`] = `
 .emotion-6 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-weight: 800;
   line-height: 16px;
@@ -158,8 +151,7 @@ exports[`<Markdown /> renders 1`] = `
 .emotion-8 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -174,8 +166,7 @@ exports[`<Markdown /> renders 1`] = `
 .emotion-11 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-style: italic;
   font-weight: 400;
@@ -185,8 +176,7 @@ exports[`<Markdown /> renders 1`] = `
 .emotion-29 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   list-style-position: inside;
   margin: 0;

--- a/packages/react-components/modals/src/AlertDialog/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/AlertDialog/__snapshots__/index.spec.tsx.snap
@@ -165,8 +165,7 @@ exports[`<AlertModal /> isOpen renders the modal via a portal when true 1`] = `
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -188,8 +187,7 @@ exports[`<AlertModal /> isOpen renders the modal via a portal when true 1`] = `
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -270,8 +268,7 @@ exports[`<AlertModal /> isOpen renders the modal via a portal when true 1`] = `
 .emotion-3 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -285,8 +282,7 @@ exports[`<AlertModal /> isOpen renders the modal via a portal when true 1`] = `
 .emotion-5 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;

--- a/packages/react-components/text/src/baseStyle.ts
+++ b/packages/react-components/text/src/baseStyle.ts
@@ -3,9 +3,6 @@ import { css } from '@emotion/core';
 
 export default css('-webkit-font-smoothing: antialiased;', {
   color: tokens.color.primary.navyText.value.rgb,
-  fontFamily: [
-    tokens.asset.font.sansSerif.attributes.fallback,
-    tokens.asset.font.sansSerif.value,
-  ],
+  fontFamily: `${tokens.asset.font.sansSerif.value}, ${tokens.asset.font.sansSerif.attributes.fallback}`,
   fontStyle: 'normal',
 });

--- a/packages/react-components/text/src/components/List/__snapshots__/List.spec.tsx.snap
+++ b/packages/react-components/text/src/components/List/__snapshots__/List.spec.tsx.snap
@@ -4,8 +4,7 @@ exports[`List renders an ordered list 1`] = `
 .emotion-4 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   list-style-position: inside;
   margin: 0;
@@ -64,8 +63,7 @@ exports[`List renders an unordered list 1`] = `
 .emotion-4 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   list-style-position: inside;
   margin: 0;

--- a/packages/react-components/text/src/components/__snapshots__/Badge.spec.tsx.snap
+++ b/packages/react-components/text/src/components/__snapshots__/Badge.spec.tsx.snap
@@ -4,8 +4,7 @@ exports[`Badge renders with the provided colour, className and content 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-weight: 800;
   line-height: 16px;

--- a/packages/react-components/text/src/components/__snapshots__/Emphasis.spec.tsx.snap
+++ b/packages/react-components/text/src/components/__snapshots__/Emphasis.spec.tsx.snap
@@ -4,8 +4,7 @@ exports[`<Emphasis /> renders 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-style: italic;
   font-weight: 400;

--- a/packages/react-components/text/src/components/__snapshots__/Heading.spec.tsx.snap
+++ b/packages/react-components/text/src/components/__snapshots__/Heading.spec.tsx.snap
@@ -4,8 +4,7 @@ exports[`<Heading /> renders at each size renders at size 200, multiLine=false 1
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -38,8 +37,7 @@ exports[`<Heading /> renders at each size renders at size 200, multiLine=true 1`
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -71,8 +69,7 @@ exports[`<Heading /> renders at each size renders at size 300, multiLine=false 1
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -105,8 +102,7 @@ exports[`<Heading /> renders at each size renders at size 300, multiLine=true 1`
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -138,8 +134,7 @@ exports[`<Heading /> renders at each size renders at size 400, multiLine=false 1
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -172,8 +167,7 @@ exports[`<Heading /> renders at each size renders at size 400, multiLine=true 1`
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -205,8 +199,7 @@ exports[`<Heading /> renders at each size renders at size 500, multiLine=false 1
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -239,8 +232,7 @@ exports[`<Heading /> renders at each size renders at size 500, multiLine=true 1`
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -272,8 +264,7 @@ exports[`<Heading /> renders at each size renders at size 600, multiLine=false 1
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -306,8 +297,7 @@ exports[`<Heading /> renders at each size renders at size 600, multiLine=true 1`
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -339,8 +329,7 @@ exports[`<Heading /> renders at each size renders at size 650, multiLine=false 1
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -373,8 +362,7 @@ exports[`<Heading /> renders at each size renders at size 650, multiLine=true 1`
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -406,8 +394,7 @@ exports[`<Heading /> renders at each size renders at size 700, multiLine=false 1
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -440,8 +427,7 @@ exports[`<Heading /> renders at each size renders at size 700, multiLine=true 1`
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -473,8 +459,7 @@ exports[`<Heading /> renders at each size renders at size 800, multiLine=false 1
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -507,8 +492,7 @@ exports[`<Heading /> renders at each size renders at size 800, multiLine=true 1`
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -540,8 +524,7 @@ exports[`<Heading /> renders at each size renders at size 900, multiLine=false 1
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -574,8 +557,7 @@ exports[`<Heading /> renders at each size renders at size 900, multiLine=true 1`
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;

--- a/packages/react-components/text/src/components/__snapshots__/Link.spec.tsx.snap
+++ b/packages/react-components/text/src/components/__snapshots__/Link.spec.tsx.snap
@@ -4,8 +4,7 @@ exports[`<Text /> renders with a string 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: #007bb6;
   cursor: pointer;

--- a/packages/react-components/text/src/components/__snapshots__/Paragraph.spec.tsx.snap
+++ b/packages/react-components/text/src/components/__snapshots__/Paragraph.spec.tsx.snap
@@ -4,8 +4,7 @@ exports[`<Paragraph /> renders with Strong, Small, Text, Link and Emphasis child
 .emotion-5 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -20,8 +19,7 @@ exports[`<Paragraph /> renders with Strong, Small, Text, Link and Emphasis child
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-weight: 800;
   line-height: 16px;
@@ -30,8 +28,7 @@ exports[`<Paragraph /> renders with Strong, Small, Text, Link and Emphasis child
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -41,8 +38,7 @@ exports[`<Paragraph /> renders with Strong, Small, Text, Link and Emphasis child
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 14px;
   line-height: 16px;
@@ -51,8 +47,7 @@ exports[`<Paragraph /> renders with Strong, Small, Text, Link and Emphasis child
 .emotion-3 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-style: italic;
   font-weight: 400;
@@ -62,8 +57,7 @@ exports[`<Paragraph /> renders with Strong, Small, Text, Link and Emphasis child
 .emotion-4 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: #007bb6;
   cursor: pointer;
@@ -126,8 +120,7 @@ exports[`<Paragraph /> renders with a string 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;

--- a/packages/react-components/text/src/components/__snapshots__/Small.spec.tsx.snap
+++ b/packages/react-components/text/src/components/__snapshots__/Small.spec.tsx.snap
@@ -4,8 +4,7 @@ exports[`<Small /> renders with Strong and Emphasis children 1`] = `
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 14px;
   line-height: 16px;
@@ -14,8 +13,7 @@ exports[`<Small /> renders with Strong and Emphasis children 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-weight: 800;
   line-height: 16px;
@@ -24,8 +22,7 @@ exports[`<Small /> renders with Strong and Emphasis children 1`] = `
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-style: italic;
   font-weight: 400;
@@ -58,8 +55,7 @@ exports[`<Small /> renders with a string 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 14px;
   line-height: 16px;

--- a/packages/react-components/text/src/components/__snapshots__/Strong.spec.tsx.snap
+++ b/packages/react-components/text/src/components/__snapshots__/Strong.spec.tsx.snap
@@ -4,8 +4,7 @@ exports[`<Strong /> renders 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-weight: 800;
   line-height: 16px;

--- a/packages/react-components/text/src/components/__snapshots__/Text.spec.tsx.snap
+++ b/packages/react-components/text/src/components/__snapshots__/Text.spec.tsx.snap
@@ -4,8 +4,7 @@ exports[`<Text /> renders with Small children 1`] = `
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -15,8 +14,7 @@ exports[`<Text /> renders with Small children 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 14px;
   line-height: 16px;
@@ -41,8 +39,7 @@ exports[`<Text /> renders with Strong children 1`] = `
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;
@@ -52,8 +49,7 @@ exports[`<Text /> renders with Strong children 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-weight: 800;
   line-height: 16px;
@@ -78,8 +74,7 @@ exports[`<Text /> renders with a string 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-size: 16px;
   font-weight: 400;

--- a/packages/react-components/toast/src/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/toast/src/__snapshots__/index.spec.tsx.snap
@@ -49,8 +49,7 @@ exports[`toast mounts a success toast 1`] = `
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;
@@ -199,8 +198,7 @@ exports[`toast mounts an error toast 1`] = `
 .emotion-2 {
   -webkit-font-smoothing: antialiased;
   color: rgb(5,25,45);
-  font-family: Arial;
-  font-family: Studio-Feixen-Sans;
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   color: rgb(5,25,45);
   font-weight: 800;


### PR DESCRIPTION
## Proposed changes
The previous font improvements didn't totally work when using just react. This fixes the fallback