### PR TITLE
Use a higher z-index for the modal overlay style

### DIFF
--- a/packages/react-components/modals/src/AlertDialog/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/AlertDialog/__snapshots__/index.spec.tsx.snap
@@ -78,7 +78,7 @@ exports[`<AlertModal /> isOpen renders the modal via a portal when true 1`] = `
   top: 0;
   -webkit-transition: opacity 0.6s cubic-bezier(0.19,1,0.22,1);
   transition: opacity 0.6s cubic-bezier(0.19,1,0.22,1);
-  z-index: 100;
+  z-index: 900;
 }
 
 .emotion-14 {

--- a/packages/react-components/modals/src/Dialog/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/Dialog/__snapshots__/index.spec.tsx.snap
@@ -78,7 +78,7 @@ exports[`<Dialog /> isOpen renders the modal via a portal when true 1`] = `
   top: 0;
   -webkit-transition: opacity 0.6s cubic-bezier(0.19,1,0.22,1);
   transition: opacity 0.6s cubic-bezier(0.19,1,0.22,1);
-  z-index: 100;
+  z-index: 900;
 }
 
 .emotion-6 {

--- a/packages/react-components/modals/src/Panel/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/Panel/__snapshots__/index.spec.tsx.snap
@@ -64,7 +64,7 @@ exports[`<Panel /> isOpen renders the modal via a portal when true 1`] = `
   top: 0;
   -webkit-transition: opacity 0.6s cubic-bezier(0.19,1,0.22,1);
   transition: opacity 0.6s cubic-bezier(0.19,1,0.22,1);
-  z-index: 100;
+  z-index: 900;
 }
 
 .emotion-6 {

--- a/packages/react-components/modals/src/sharedStyles.ts
+++ b/packages/react-components/modals/src/sharedStyles.ts
@@ -18,7 +18,7 @@ export const overlayStyle = css({
   right: 0,
   top: 0,
   transition: `opacity 0.6s cubic-bezier(0.19, 1, 0.22, 1)`,
-  zIndex: parseInt(tokens.zIndex[100].value, 10),
+  zIndex: 900,
 });
 
 export const overlayStyleAfterOpen = css`


### PR DESCRIPTION
## Proposed changes

The modal background only has a z-index of 100 but a lot of elements in DC apps have a higher z-index. IMO it makes sense to give the modal background the highest z-index possible. Below you see an example of the marketing app where the navbar has a higher z-index.
![image](https://user-images.githubusercontent.com/12659249/96368898-e9110b00-1156-11eb-91cb-020b98f4c56e.png)

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- ~~[ ] Technical docs written~~
- ~~[ ] Structural changes reflected in Readme~~
- ~~[ ] Migration plan for breaking changes~~

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
