### PR TITLE
WF-444 Make anchors on flashes navy

### DIFF
--- a/packages/stylesheets/flash-banner/lib/_flash-banner.scss
+++ b/packages/stylesheets/flash-banner/lib/_flash-banner.scss
@@ -121,15 +121,15 @@
 
 // Yellow / Notice
 .dc-flash--notice {
-  @include color-flash($bg: $dc-yellow, $link-color: $dc-blue, $link-hover: $dc-blue);
+  @include color-flash($bg: $dc-yellow, $link-color: $dc-navy-text, $link-hover: $dc-navy-text);
 }
 
 // Green / Success
 .dc-flash--success {
-  @include color-flash($bg: $dc-green, $link-color: $dc-blue, $link-hover: $dc-blue);
+  @include color-flash($bg: $dc-green, $link-color: $dc-navy-text, $link-hover: $dc-navy-text);
 }
 
 // Red / Error
 .dc-flash--error {
-  @include color-flash($bg: $dc-red, $link-color: $dc-blue, $link-hover: $dc-blue);
+  @include color-flash($bg: $dc-red, $link-color: $dc-navy-text, $link-hover: $dc-navy-text);
 }


### PR DESCRIPTION
## Proposed changes
The pricing page which is affected uses `react` layout which does not include assets generated by Rails application, so I made the change here.

~Wonder if `dc-flash--notice` & `dc-flash--info` should have the color updated as well? (https://waffles.datacamp.com/stylesheets/flash-banner#)~ -> updated as well

**Before:**

![image](https://user-images.githubusercontent.com/4058382/96992425-2d6f2300-152a-11eb-912b-412f921898be.png)



**After:**

![image](https://user-images.githubusercontent.com/4058382/96992472-3cee6c00-152a-11eb-8880-3561e855570c.png)