### PR TITLE
WF-409 remove reference to old colour on text docs

### DIFF
--- a/packages/docs/catalog-doc-site/catalog/pages/componentLibrary/text.js
+++ b/packages/docs/catalog-doc-site/catalog/pages/componentLibrary/text.js
@@ -148,7 +148,7 @@ export default () => {
   <CodeBlock>{\`gapminder %>%
 filter(year == 2007) %>%
 arrange(desc(gdpPercap))\`}</CodeBlock>
-  <Badge color={colors.primary} size="large">
+  <Badge color={colors.navy} size="large">
     Badge
   </Badge>
 </>`}


### PR DESCRIPTION
## Proposed changes
An old colour was still used in an example

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
