### PR TITLE
WF-435 radio button positioning in IE11

### DIFF
--- a/packages/react-components/form-elements/src/RadioList/RadioIcon.tsx
+++ b/packages/react-components/form-elements/src/RadioList/RadioIcon.tsx
@@ -23,6 +23,7 @@ const RadioIcon: React.FC<{
           height: '18px',
           opacity: disabled ? 0.3 : 1,
           position: 'absolute',
+          top: '0px',
           width: '18px',
         })}
       />
@@ -36,6 +37,7 @@ const RadioIcon: React.FC<{
             marginLeft: '5px',
             opacity: disabled ? 0.3 : 1,
             position: 'absolute',
+            top: '5px',
             width: '8px',
           }}
         />

--- a/packages/react-components/form-elements/src/RadioList/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/form-elements/src/RadioList/__snapshots__/index.spec.tsx.snap
@@ -109,6 +109,7 @@ exports[`<RadioList> snapshots renders a radio list 1`] = `
   height: 18px;
   opacity: 1;
   position: absolute;
+  top: 0px;
   width: 18px;
 }
 
@@ -120,6 +121,7 @@ exports[`<RadioList> snapshots renders a radio list 1`] = `
   margin-left: 5px;
   opacity: 1;
   position: absolute;
+  top: 5px;
   width: 8px;
 }
 
@@ -164,6 +166,7 @@ exports[`<RadioList> snapshots renders a radio list 1`] = `
   height: 18px;
   opacity: 0.3;
   position: absolute;
+  top: 0px;
   width: 18px;
 }
 


### PR DESCRIPTION
## Proposed changes
Radio buttons appeared very wonky in IE11. This forces the positioning a bit more explicitly to make things line up as they should.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
