### PR TITLE
WF-388 disabled buttons with type="link"

### DIFF
--- a/packages/react-components/button/src/Button/index.spec.tsx
+++ b/packages/react-components/button/src/Button/index.spec.tsx
@@ -80,6 +80,18 @@ describe('<Button />', () => {
     expect(buttonElement).toHaveAttribute('disabled');
   });
 
+  it('disables a link button', async () => {
+    const onClick = jest.fn();
+    const { getByText } = await axeRender(
+      <Button disabled href="abc" onClick={onClick} type="link">
+        disabled link button
+      </Button>,
+    );
+
+    userEvent.click(getByText('disabled link button') as HTMLElement);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
   describe('button size', () => {
     it('renders the small button for the size="small" ', async () => {
       const { queryByText, container } = await axeRender(

--- a/packages/react-components/button/src/Button/index.tsx
+++ b/packages/react-components/button/src/Button/index.tsx
@@ -18,7 +18,6 @@ import { mergeRefs } from 'use-callback-ref';
 import Tooltip from '../Tooltip';
 
 import {
-  baseColors,
   baseLoadingStyle,
   baseStyle,
   fontSizes,
@@ -228,7 +227,16 @@ const InternalButton = (
         return {
           Element: 'a',
           href: props.href,
-          onClick: props.onClick,
+          // disabled prop does nothing on an anchor tag. This explicitly stops navigation on disabled link buttons
+          onClick:
+            disabled || loading
+              ? (
+                  e: React.MouseEvent<
+                    HTMLAnchorElement | HTMLButtonElement,
+                    MouseEvent
+                  >,
+                ) => e.preventDefault()
+              : props.onClick,
           target: props.target,
         } as const;
       case 'submit':


### PR DESCRIPTION
## Proposed changes
Buttons with `type="link"` didn't disable properly since the `disabled` attribute doesn't exist for anchor elements. This explicitly blocks anchor functionality when the `disabled` prop is set.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
