### PR TITLE
WF-470 fix: expand range of icons peer dependency to include latest versions

### DIFF
--- a/packages/react-components/button/package.json
+++ b/packages/react-components/button/package.json
@@ -2,20 +2,14 @@
   "name": "@datacamp/waffles-button",
   "version": "6.3.0",
   "description": "The Waffles Button",
-  "keywords": [
-    "button"
-  ],
+  "keywords": ["button"],
   "author": "Dan Denney <dd.subscriptions@gmail.com>",
   "homepage": "https://github.com/datacamp/design-system/tree/master/packages/button/README.md",
   "license": "MIT",
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "types/index.d.ts",
-  "files": [
-    "es",
-    "lib",
-    "types"
-  ],
+  "files": ["es", "lib", "types"],
   "scripts": {
     "build:cjs": "BABEL_ENV=cjs babel src --extensions '.tsx','.ts' --out-dir lib --ignore \"src/**/*.spec.tsx\",\"src/**/*.spec.ts\" --config-file ./babel7.config.js",
     "build:es": "BABEL_ENV=es babel src --extensions '.tsx','.ts' --out-dir es --ignore \"src/**/*.spec.tsx\",\"src/**/*.spec.ts\" --config-file ./babel7.config.js",
@@ -70,7 +64,7 @@
     "use-callback-ref": "^1.2.4"
   },
   "peerDependencies": {
-    "@datacamp/waffles-icons": "^1.3.3",
+    "@datacamp/waffles-icons": "^1.3.3 || ^2.0.0",
     "@emotion/core": "^10.0.17",
     "react": "^16.8.6 || ^17.0.1",
     "react-dom": "^16.8.6 || ^17.0.1"


### PR DESCRIPTION
We are actually still compatible, so to avoid making a breaking change I have just widened the range