### PR TITLE
fix: remove overflow hidden from resizable elements

### DIFF
--- a/packages/react-components/resizable-elements/src/ResizableElements.tsx
+++ b/packages/react-components/resizable-elements/src/ResizableElements.tsx
@@ -173,7 +173,6 @@ const ResizableElements = ({
               css={{
                 [fixedDimension]: '100%',
                 float: 'left',
-                overflow: 'hidden',
                 position: 'relative',
               }}
               style={{

--- a/packages/react-components/resizable-elements/src/__snapshots__/ResizableElements.spec.tsx.snap
+++ b/packages/react-components/resizable-elements/src/__snapshots__/ResizableElements.spec.tsx.snap
@@ -17,7 +17,6 @@ exports[`ResizableElements renders the correct sized elements 1`] = `
 .emotion-1 {
   height: 100%;
   float: left;
-  overflow: hidden;
   position: relative;
 }
 


### PR DESCRIPTION
Might break something, but it's needed by LX, they're the only ones using it atm, so should be fine.
