### PR TITLE
WF-469 Prop types errors

### DIFF
--- a/packages/other/utils/package.json
+++ b/packages/other/utils/package.json
@@ -8,11 +8,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "types/index.d.ts",
-  "files": [
-    "es",
-    "lib",
-    "types"
-  ],
+  "files": ["es", "lib", "types"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/datacamp/design-system.git"
@@ -42,7 +38,8 @@
     "@babel/runtime": "^7.12.1",
     "@types/airbnb-prop-types": "^2.13.1",
     "airbnb-prop-types": "^2.16.0",
-    "lodash": "^4.17.20"
+    "lodash": "^4.17.20",
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.8.6 || ^17.0.1"

--- a/packages/other/utils/package.json
+++ b/packages/other/utils/package.json
@@ -40,6 +40,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.1",
+    "@types/airbnb-prop-types": "^2.13.1",
+    "airbnb-prop-types": "^2.16.0",
     "lodash": "^4.17.20"
   },
   "peerDependencies": {

--- a/packages/other/utils/src/childrenOfType.ts
+++ b/packages/other/utils/src/childrenOfType.ts
@@ -1,5 +1,23 @@
-import { childrenOfType as original } from 'airbnb-prop-types';
+import { childrenOfType as original, ReactTypeLike } from 'airbnb-prop-types';
+import PropTypes from 'prop-types';
 
-const childrenOfType: typeof original = (...types) => original(...types);
+function isEmotionType(...types: ReactTypeLike[]) {
+  return function validator(
+    props: { [key: string]: any },
+    propName: string,
+    componentName: string,
+  ): Error | null {
+    const propValue = props[propName];
+    if (types.includes(propValue?.props?.__EMOTION_TYPE_PLEASE_DO_NOT_USE__)) {
+      return null;
+    }
+    return new Error(`Invalid prop ${propName} provided to ${componentName}`);
+  };
+}
+
+const childrenOfType = (
+  ...types: ReactTypeLike[]
+): PropTypes.Requireable<unknown> =>
+  PropTypes.oneOfType([original(...types), isEmotionType(...types)]);
 
 export default childrenOfType;

--- a/packages/other/utils/src/childrenOfType.ts
+++ b/packages/other/utils/src/childrenOfType.ts
@@ -1,0 +1,5 @@
+import { childrenOfType as original } from 'airbnb-prop-types';
+
+const childrenOfType: typeof original = (...types) => original(...types);
+
+export default childrenOfType;

--- a/packages/other/utils/src/index.spec.ts
+++ b/packages/other/utils/src/index.spec.ts
@@ -1,3 +1,4 @@
+import childrenOfType from './childrenOfType';
 import computeDataAttributes from './computeDataAttributes';
 import isChildType from './isChildType';
 import ssrSafeNotFirstChildSelector from './ssrSafeNotFirstChildSelector';
@@ -7,6 +8,7 @@ import * as utils from '.';
 describe('waffles-utils', () => {
   it('exposes all the utils', () => {
     expect(utils).toEqual({
+      childrenOfType,
       computeDataAttributes,
       isChildType,
       ssrSafeNotFirstChildSelector,

--- a/packages/other/utils/src/index.ts
+++ b/packages/other/utils/src/index.ts
@@ -1,3 +1,4 @@
 export { default as computeDataAttributes } from './computeDataAttributes';
 export { default as isChildType } from './isChildType';
 export { default as ssrSafeNotFirstChildSelector } from './ssrSafeNotFirstChildSelector';
+export { default as childrenOfType } from './childrenOfType';

--- a/packages/react-components/button/src/Button/index.tsx
+++ b/packages/react-components/button/src/Button/index.tsx
@@ -2,9 +2,9 @@ import * as Icons from '@datacamp/waffles-icons';
 import { Text } from '@datacamp/waffles-text';
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
 import Tooltip from '@datacamp/waffles-tooltip';
-import { computeDataAttributes } from '@datacamp/waffles-utils';
+import { childrenOfType, computeDataAttributes } from '@datacamp/waffles-utils';
 import { css, SerializedStyles } from '@emotion/react';
-import { childrenOfType, nChildren } from 'airbnb-prop-types';
+import { nChildren } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
 import React, {
   ComponentProps,

--- a/packages/react-components/button/src/ButtonGroup/index.tsx
+++ b/packages/react-components/button/src/ButtonGroup/index.tsx
@@ -1,7 +1,6 @@
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
-import { isChildType } from '@datacamp/waffles-utils';
+import { childrenOfType, isChildType } from '@datacamp/waffles-utils';
 import { ClassNames } from '@emotion/react';
-import { childrenOfType } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/packages/react-components/button/src/CompactButtonGroup/index.tsx
+++ b/packages/react-components/button/src/CompactButtonGroup/index.tsx
@@ -1,5 +1,5 @@
+import { childrenOfType } from '@datacamp/waffles-utils';
 import { ClassNames } from '@emotion/react';
-import { childrenOfType } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/packages/react-components/form-elements/src/CheckboxList/index.tsx
+++ b/packages/react-components/form-elements/src/CheckboxList/index.tsx
@@ -1,4 +1,4 @@
-import { childrenOfType } from 'airbnb-prop-types';
+import { childrenOfType } from '@datacamp/waffles-utils';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, { ReactElement } from 'react';

--- a/packages/react-components/form-elements/src/RadioList/index.tsx
+++ b/packages/react-components/form-elements/src/RadioList/index.tsx
@@ -1,4 +1,4 @@
-import { childrenOfType } from 'airbnb-prop-types';
+import { childrenOfType } from '@datacamp/waffles-utils';
 import PropTypes from 'prop-types';
 import React, { ReactElement } from 'react';
 

--- a/packages/react-components/form-elements/src/Select/index.tsx
+++ b/packages/react-components/form-elements/src/Select/index.tsx
@@ -1,8 +1,7 @@
 import { ChevronDownIcon } from '@datacamp/waffles-icons';
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
-import { computeDataAttributes } from '@datacamp/waffles-utils';
+import { childrenOfType, computeDataAttributes } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
-import { childrenOfType } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
 import React, { Component, forwardRef, ReactElement, Ref } from 'react';
 

--- a/packages/react-components/modals/src/shared/Footer.tsx
+++ b/packages/react-components/modals/src/shared/Footer.tsx
@@ -1,7 +1,8 @@
 import Button, { ButtonGroup } from '@datacamp/waffles-button';
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
+import { childrenOfType } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
-import { childrenOfType, nChildren } from 'airbnb-prop-types';
+import { nChildren } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
 import React, { ReactElement } from 'react';
 

--- a/packages/react-components/text/src/components/Emphasis.tsx
+++ b/packages/react-components/text/src/components/Emphasis.tsx
@@ -1,7 +1,6 @@
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
-import { computeDataAttributes } from '@datacamp/waffles-utils';
+import { childrenOfType, computeDataAttributes } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
-import { childrenOfType } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
 import React, { ReactElement, ReactNode } from 'react';
 

--- a/packages/react-components/text/src/components/Heading.tsx
+++ b/packages/react-components/text/src/components/Heading.tsx
@@ -1,10 +1,10 @@
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
 import {
+  childrenOfType,
   computeDataAttributes,
   ssrSafeNotFirstChildSelector,
 } from '@datacamp/waffles-utils';
 import { css, SerializedStyles } from '@emotion/react';
-import { childrenOfType } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
 import React, { ReactElement, ReactNode } from 'react';
 

--- a/packages/react-components/text/src/components/List/index.tsx
+++ b/packages/react-components/text/src/components/List/index.tsx
@@ -1,9 +1,9 @@
 import {
+  childrenOfType,
   computeDataAttributes,
   ssrSafeNotFirstChildSelector,
 } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
-import { childrenOfType } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
 import React, { ReactElement, ReactNode } from 'react';
 

--- a/packages/react-components/text/src/components/Paragraph.tsx
+++ b/packages/react-components/text/src/components/Paragraph.tsx
@@ -1,10 +1,10 @@
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
 import {
+  childrenOfType,
   computeDataAttributes,
   ssrSafeNotFirstChildSelector,
 } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
-import { childrenOfType } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
 import React, { ReactElement, ReactNode } from 'react';
 

--- a/packages/react-components/text/src/components/Small.tsx
+++ b/packages/react-components/text/src/components/Small.tsx
@@ -1,7 +1,6 @@
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
-import { computeDataAttributes } from '@datacamp/waffles-utils';
+import { childrenOfType, computeDataAttributes } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
-import { childrenOfType } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
 import React, { ReactElement, ReactNode } from 'react';
 

--- a/packages/react-components/text/src/components/Strong.tsx
+++ b/packages/react-components/text/src/components/Strong.tsx
@@ -1,7 +1,6 @@
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
-import { computeDataAttributes } from '@datacamp/waffles-utils';
+import { childrenOfType, computeDataAttributes } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
-import { childrenOfType } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
 import React, { ReactElement, ReactNode } from 'react';
 

--- a/packages/react-components/text/src/components/Text.tsx
+++ b/packages/react-components/text/src/components/Text.tsx
@@ -1,7 +1,6 @@
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
-import { computeDataAttributes } from '@datacamp/waffles-utils';
+import { childrenOfType, computeDataAttributes } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
-import { childrenOfType } from 'airbnb-prop-types';
 import PropTypes from 'prop-types';
 import React, { ReactElement, ReactNode } from 'react';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4544,7 +4544,7 @@
   dependencies:
     "@babel/runtime" "^7.10.2"
 
-"@types/airbnb-prop-types@2.13.1":
+"@types/airbnb-prop-types@2.13.1", "@types/airbnb-prop-types@^2.13.1":
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/@types/airbnb-prop-types/-/airbnb-prop-types-2.13.1.tgz#9290689e95547cf2ab809585f553edef48cb20e9"
   integrity sha512-EfUWjD7bqrspzWCBwnoaglrtJNqdyqYTWg6JxjWhOs9URskzQ/tR+OyYJbaIzGplqPRusYFc8Slt7f1MQLMdNQ==


### PR DESCRIPTION
## Proposed changes
Creates a new `childrenOfType` validator that extends the airbnb one we were previously using. This should now allow for emotion styled children to stop throwing warnings.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [ ] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
