### PR TITLE
fix: make fixed size panel work on narrow screens

### DIFF
--- a/packages/react-components/modals/src/Panel/PanelStyles.ts
+++ b/packages/react-components/modals/src/Panel/PanelStyles.ts
@@ -4,6 +4,7 @@ export const animationTime = 600;
 const baseContentStyle = css({
   bottom: '0',
   margin: 'auto',
+  maxWidth: '100%',
   opacity: 0,
   outline: 'none',
   position: 'absolute',

--- a/packages/react-components/modals/src/Panel/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/Panel/__snapshots__/index.spec.tsx.snap
@@ -51,6 +51,7 @@ exports[`<Panel /> isOpen renders the modal via a portal when true 1`] = `
 .emotion-3 {
   bottom: 0;
   margin: auto;
+  max-width: 100%;
   opacity: 0;
   outline: none;
   position: absolute;


### PR DESCRIPTION
When the width prop of a panel is set to a fixed width in pixels, the panel isn't restricted to 100% of the width on narrow screens as modals are. This small change makes panel behaviour similar to that of modals.