### PR TITLE
WF-475 move circular references to allow systemjs bundles

### DIFF
--- a/packages/react-components/text/src/components/Emphasis.tsx
+++ b/packages/react-components/text/src/components/Emphasis.tsx
@@ -1,14 +1,11 @@
+/* eslint-disable global-require */
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
 import { childrenOfType, computeDataAttributes } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
 import React, { ReactElement, ReactNode } from 'react';
 
-import PlainString from '../alternateComponents/PlainString';
 import baseStyle from '../baseStyle';
-
-import Strong from './Strong';
-import Text from './Text';
 
 interface EmphasisProps {
   /**
@@ -48,10 +45,12 @@ const Emphasis = ({
   );
 };
 
+export default Emphasis;
+
 const validChildType = PropTypes.oneOfType([
-  childrenOfType(Text),
-  childrenOfType(Strong),
-  childrenOfType(PlainString),
+  childrenOfType(require('./Text')),
+  childrenOfType(require('./Strong')),
+  childrenOfType(require('../alternateComponents/PlainString')),
   PropTypes.string,
   PropTypes.number,
 ]);
@@ -62,5 +61,3 @@ Emphasis.propTypes = {
     PropTypes.arrayOf(validChildType),
   ]),
 };
-
-export default Emphasis;

--- a/packages/react-components/text/src/components/Heading.tsx
+++ b/packages/react-components/text/src/components/Heading.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
 import {
   childrenOfType,
@@ -8,10 +9,7 @@ import { css, SerializedStyles } from '@emotion/react';
 import PropTypes from 'prop-types';
 import React, { ReactElement, ReactNode } from 'react';
 
-import PlainString from '../alternateComponents/PlainString';
 import baseStyle from '../baseStyle';
-
-import Strong from './Strong';
 
 export type Size = 200 | 300 | 400 | 500 | 600 | 650 | 700 | 800 | 900;
 export type HeadingElement = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
@@ -118,8 +116,8 @@ const Heading = ({
 Heading.defaultProps = { multiLine: false };
 
 const validChildType = PropTypes.oneOfType([
-  childrenOfType(Strong),
-  childrenOfType(PlainString),
+  childrenOfType(require('./Strong')),
+  childrenOfType(require('../alternateComponents/PlainString')),
   PropTypes.string,
   PropTypes.number,
 ]);

--- a/packages/react-components/text/src/components/Paragraph.tsx
+++ b/packages/react-components/text/src/components/Paragraph.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable global-require */
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
 import {
   childrenOfType,
@@ -8,16 +9,7 @@ import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
 import React, { ReactElement, ReactNode } from 'react';
 
-import AlternateCode from '../alternateComponents/AlternateCode';
-import PlainString from '../alternateComponents/PlainString';
 import baseStyle from '../baseStyle';
-
-import Code from './Code';
-import Emphasis from './Emphasis';
-import Link from './Link';
-import Small from './Small';
-import Strong from './Strong';
-import Text from './Text';
 
 interface ParagraphProps {
   /**
@@ -61,14 +53,14 @@ const Paragraph = ({
 };
 
 const validChildType = PropTypes.oneOfType([
-  childrenOfType(Strong),
-  childrenOfType(Text),
-  childrenOfType(Small),
-  childrenOfType(Emphasis),
-  childrenOfType(Code),
-  childrenOfType(Link),
-  childrenOfType(AlternateCode),
-  childrenOfType(PlainString),
+  childrenOfType(require('./Strong')),
+  childrenOfType(require('./Text')),
+  childrenOfType(require('./Small')),
+  childrenOfType(require('./Emphasis')),
+  childrenOfType(require('./Code')),
+  childrenOfType(require('./Link')),
+  childrenOfType(require('../alternateComponents/AlternateCode')),
+  childrenOfType(require('../alternateComponents/PlainString')),
   childrenOfType('br'),
   childrenOfType('del'),
   childrenOfType('img'),

--- a/packages/react-components/text/src/components/Small.tsx
+++ b/packages/react-components/text/src/components/Small.tsx
@@ -1,14 +1,11 @@
+/* eslint-disable global-require */
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
 import { childrenOfType, computeDataAttributes } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
 import React, { ReactElement, ReactNode } from 'react';
 
-import PlainString from '../alternateComponents/PlainString';
 import baseStyle from '../baseStyle';
-
-import Emphasis from './Emphasis';
-import Strong from './Strong';
 
 interface SmallProps {
   /**
@@ -48,9 +45,9 @@ const Small = ({
 };
 
 const validChildType = PropTypes.oneOfType([
-  childrenOfType(Strong),
-  childrenOfType(Emphasis),
-  childrenOfType(PlainString),
+  childrenOfType(require('./Strong')),
+  childrenOfType(require('./Emphasis')),
+  childrenOfType(require('../alternateComponents/PlainString')),
   PropTypes.string,
   PropTypes.number,
 ]);

--- a/packages/react-components/text/src/components/Strong.tsx
+++ b/packages/react-components/text/src/components/Strong.tsx
@@ -1,14 +1,11 @@
+/* eslint-disable global-require */
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
 import { childrenOfType, computeDataAttributes } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
 import React, { ReactElement, ReactNode } from 'react';
 
-import PlainString from '../alternateComponents/PlainString';
 import baseStyle from '../baseStyle';
-
-import Emphasis from './Emphasis';
-import Text from './Text';
 
 interface StrongProps {
   /**
@@ -47,10 +44,12 @@ const Strong = ({
   );
 };
 
+export default Strong;
+
 const validChildType = PropTypes.oneOfType([
-  childrenOfType(Text),
-  childrenOfType(Emphasis),
-  childrenOfType(PlainString),
+  childrenOfType(require('./Text')),
+  childrenOfType(require('./Emphasis')),
+  childrenOfType(require('../alternateComponents/PlainString')),
 
   PropTypes.string,
   PropTypes.number,
@@ -62,5 +61,3 @@ Strong.propTypes = {
     PropTypes.arrayOf(validChildType),
   ]),
 };
-
-export default Strong;

--- a/packages/react-components/text/src/components/Text.tsx
+++ b/packages/react-components/text/src/components/Text.tsx
@@ -1,15 +1,11 @@
+/* eslint-disable global-require */
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
 import { childrenOfType, computeDataAttributes } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
 import React, { ReactElement, ReactNode } from 'react';
 
-import PlainString from '../alternateComponents/PlainString';
 import baseStyle from '../baseStyle';
-
-import Emphasis from './Emphasis';
-import Small from './Small';
-import Strong from './Strong';
 
 export interface TextProps {
   /**
@@ -48,11 +44,13 @@ const Text = ({
   );
 };
 
+export default Text;
+
 const validChildType = PropTypes.oneOfType([
-  childrenOfType(Small),
-  childrenOfType(Emphasis),
-  childrenOfType(Strong),
-  childrenOfType(PlainString),
+  childrenOfType(require('./Small')),
+  childrenOfType(require('./Emphasis')),
+  childrenOfType(require('./Strong')),
+  childrenOfType(require('../alternateComponents/PlainString')),
   PropTypes.string,
   PropTypes.number,
 ]);
@@ -63,5 +61,3 @@ Text.propTypes = {
     PropTypes.arrayOf(validChildType),
   ]),
 };
-
-export default Text;


### PR DESCRIPTION
## Proposed changes
In order for the circular references to work in system JS bundles they need to be loaded this way
