### PR TITLE
fix: make positioner work in modals

### DIFF
--- a/packages/react-components/modals/src/AlertDialog/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/AlertDialog/__snapshots__/index.spec.tsx.snap
@@ -67,6 +67,7 @@ exports[`<AlertModal /> isOpen renders the modal via a portal when true 1`] = `
   min-width: 0;
   opacity: 0;
   outline: none;
+  position: relative;
   -webkit-transform: scale(0.5);
   -moz-transform: scale(0.5);
   -ms-transform: scale(0.5);
@@ -81,10 +82,10 @@ exports[`<AlertModal /> isOpen renders the modal via a portal when true 1`] = `
 
 .emotion-4 {
   opacity: 1!important;
-  -webkit-transform: scale(1)!important;
-  -moz-transform: scale(1)!important;
-  -ms-transform: scale(1)!important;
-  transform: scale(1)!important;
+  -webkit-transform: none!important;
+  -moz-transform: none!important;
+  -ms-transform: none!important;
+  transform: none!important;
 }
 
 .emotion-5 {

--- a/packages/react-components/modals/src/BaseDialog/DialogStyles.ts
+++ b/packages/react-components/modals/src/BaseDialog/DialogStyles.ts
@@ -10,13 +10,14 @@ export const contentStyle = css({
   minWidth: 0,
   opacity: 0,
   outline: 'none',
+  position: 'relative',
   transform: 'scale(0.5)',
   transition: `0.4s cubic-bezier(0.19, 1, 0.22, 1);`,
 });
 
 export const contentStyleAfterOpen = css`
   opacity: 1 !important;
-  transform: scale(1) !important;
+  transform: none !important;
 `;
 
 export const contentStyleBeforeClose = css`

--- a/packages/react-components/modals/src/Dialog/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/Dialog/__snapshots__/index.spec.tsx.snap
@@ -67,6 +67,7 @@ exports[`<Dialog /> isOpen renders the modal via a portal when true 1`] = `
   min-width: 0;
   opacity: 0;
   outline: none;
+  position: relative;
   -webkit-transform: scale(0.5);
   -moz-transform: scale(0.5);
   -ms-transform: scale(0.5);
@@ -81,10 +82,10 @@ exports[`<Dialog /> isOpen renders the modal via a portal when true 1`] = `
 
 .emotion-4 {
   opacity: 1!important;
-  -webkit-transform: scale(1)!important;
-  -moz-transform: scale(1)!important;
-  -ms-transform: scale(1)!important;
-  transform: scale(1)!important;
+  -webkit-transform: none!important;
+  -moz-transform: none!important;
+  -ms-transform: none!important;
+  transform: none!important;
 }
 
 .emotion-5 {


### PR DESCRIPTION
1. `transform: none` does no longer create a new coordinate system
2. `position: fixed` coordinates now correspond with `getBoundingClientRect()` values used by the positioner
3. `position: relative` contains the close button with `position: absolute` within the modal

Transform transition between scale(0.5) and none works.
A JS approach is hard because offsetParent of fixed elements inside a transformed element is null: [bugs.chromium.org/p/chromium/issues/detail?id=1086125
](bugs.chromium.org/p/chromium/issues/detail?id=1086125
)
Fix tested in Chrome, Firefox and Safari