### PR TITLE
feat: add onFocus prop to Input

### DIFF
--- a/packages/react-components/form-elements/src/Input/index.spec.tsx
+++ b/packages/react-components/form-elements/src/Input/index.spec.tsx
@@ -105,6 +105,23 @@ describe('<Input />', () => {
       expect(onBlur).toHaveBeenCalledTimes(1);
     });
 
+    it('calls the onFocus function', () => {
+      const onFocus = jest.fn();
+      const { getByRole } = render(
+        <Input
+          name={testName}
+          onChange={() => {}}
+          onFocus={onFocus}
+          value={testValue}
+        />,
+      );
+
+      const inputElement = getByRole('textbox') as HTMLElement;
+
+      fireEvent.focus(inputElement);
+      expect(onFocus).toHaveBeenCalledTimes(1);
+    });
+
     it('calls the onChange function', () => {
       const onChange = jest.fn();
       const { getByRole } = render(

--- a/packages/react-components/form-elements/src/Input/index.tsx
+++ b/packages/react-components/form-elements/src/Input/index.tsx
@@ -91,6 +91,10 @@ interface InputProps {
    */
   onChange: (value: string) => void;
   /**
+   * Called when the user focuses the input
+   */
+  onFocus?: () => void;
+  /**
    * The placeholder text to render before the user has entered a value.
    */
   placeholder?: string;
@@ -151,6 +155,7 @@ const InternalInput = ({
   name,
   onBlur,
   onChange,
+  onFocus,
   placeholder,
   required,
   size = 'medium',
@@ -170,6 +175,7 @@ const InternalInput = ({
     onChange(event.target.value);
 
   const handleBlur = (): void => onBlur && onBlur();
+  const handleFocus = (): void => onFocus && onFocus();
 
   const inputSize = css(
     { fontSize: fontSizes[size], height: heights[size] },
@@ -246,6 +252,7 @@ const InternalInput = ({
         name={name}
         onBlur={handleBlur}
         onChange={handleChange}
+        onFocus={handleFocus}
         placeholder={placeholder}
         ref={innerRef}
         required={htmlRequired}


### PR DESCRIPTION
## Proposed changes
This PR adds the `onFocus` prop to `Input`

## Functional Code

- [ ] Builds without errors
- [ ] Linter passes CI
- [ ] Unit tests written & pass CI
- [ ] Integration tests written & pass CI
- [ ] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [ ] Technical docs written
- [ ] Structural changes reflected in Readme
- [ ] Migration plan for breaking changes

## Meets Product Requirement

- [ ] Assumptions are met
- [ ] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
