### PR TITLE
fix: display loader svg as block

### DIFF
--- a/packages/react-components/loaders/src/LogomarkSpinner.tsx
+++ b/packages/react-components/loaders/src/LogomarkSpinner.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 const stroke = keyframes({ '100%': { strokeDashoffset: 0 } });
 
 const logoStartMask = keyframes({
-  '5%': {
+  '0%, 6%': {
     clipPath: 'polygon(0% -12%, 0% -12%, 169% 63%, 169% 63%)',
   },
   '100%': {
@@ -14,10 +14,10 @@ const logoStartMask = keyframes({
 });
 
 const logoEndMask = keyframes({
-  '71%': {
-    clipPath: 'polygon(0% 0%, 0% 77%, 100% 34%, 100% -44%)',
+  '0%, 71%': {
+    clipPath: 'polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -44%)',
   },
-  '95%': {
+  '96%, 100%': {
     clipPath: 'polygon(0% 0%, 0% 140%, 100% 96%, 100% -44%)',
   },
 });
@@ -36,59 +36,58 @@ const LogomarkSpinner = ({
   size = '100px',
 }: LogomarkSpinner): React.ReactElement => (
   // In Safari clip-path on SVG elements seems to break
-  <div css={{ position: 'relative', width: size }}>
-    <div css={{ paddingTop: '100%' }}>
-      <ClassNames>
-        {({ css, cx }) => (
+  <div css={{ height: size, width: size }}>
+    <ClassNames>
+      {({ css, cx }) => (
+        <div
+          className={cx(
+            className,
+            css({
+              animation: `${logoStartMask} cubic-bezier(0.65, 0, 0.55, 1) ${animationSettings}`,
+              margin: 'auto',
+              width: '76.65%',
+              willChange: 'clip-path',
+            }),
+          )}
+        >
           <div
-            className={cx(
-              className,
-              css({
-                animation: `${logoStartMask} cubic-bezier(0.65, 0, 0.55, 1) ${animationSettings}`,
-                bottom: 0,
-                left: '11.675%',
-                position: 'absolute',
-                right: '11.675%',
-                top: 0,
-              }),
-            )}
+            css={{
+              animation: `${logoEndMask} cubic-bezier(0, 0, 0.85, 1) ${animationSettings}`,
+              willChange: 'clip-path',
+            }}
           >
             <div
               css={{
-                animation: `${logoEndMask} cubic-bezier(0.3, 0.75, 1, 0.85) ${animationSettings}`,
+                clipPath: 'polygon(-0.1% -10%, 169% 65%, -0.1% 139%)',
               }}
             >
-              <div
-                css={{
-                  clipPath: 'polygon(0% -10%, 168.5% 64%, 0% 135%)',
-                }}
+              <svg
+                css={{ display: 'block' }}
+                version="1.1"
+                viewBox="0 0 2640 3444"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlnsXlink="http://www.w3.org/1999/xlink"
               >
-                <svg
-                  version="1.1"
-                  viewBox="0 0 2640 3444"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <title>Loading</title>
-                  <path
-                    css={{
-                      animation: `${stroke} cubic-bezier(0.65, 0, 0.55, 1) ${animationSettings}`,
-                      strokeDasharray: 9800,
-                      strokeDashoffset: 9800,
-                    }}
-                    d="M0 0 M2569 1056L143 2447V149l1175 673v1867l1248 715"
-                    fill="none"
-                    stroke={tokens.color.primary[color].value.hex}
-                    strokeLinejoin="round"
-                    strokeWidth="300"
-                  />
-                </svg>
-              </div>
+                <title>Loading</title>
+                <path
+                  css={{
+                    animation: `${stroke} cubic-bezier(0.65, 0, 0.55, 1) ${animationSettings}`,
+                    strokeDasharray: 9800,
+                    strokeDashoffset: 9800,
+                    willChange: 'stroke-dashoffset',
+                  }}
+                  d="M0 0 M2569 1056L143 2447V149l1175 673v1867l1248 715"
+                  fill="none"
+                  stroke={tokens.color.primary[color].value.hex}
+                  strokeLinejoin="round"
+                  strokeWidth="300"
+                />
+              </svg>
             </div>
           </div>
-        )}
-      </ClassNames>
-    </div>
+        </div>
+      )}
+    </ClassNames>
   </div>
 );
 

--- a/packages/react-components/loaders/src/__snapshots__/LogomarkSpinner.spec.tsx.snap
+++ b/packages/react-components/loaders/src/__snapshots__/LogomarkSpinner.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`LogomarkSpinner renders a white spinner 1`] = `
 @keyframes animation-0 {
-  5% {
+  0%, 6% {
     -webkit-clip-path: polygon(0% -12%, 0% -12%, 169% 63%, 169% 63%);
     clip-path: polygon(0% -12%, 0% -12%, 169% 63%, 169% 63%);
   }
@@ -14,12 +14,12 @@ exports[`LogomarkSpinner renders a white spinner 1`] = `
 }
 
 @keyframes animation-1 {
-  71% {
-    -webkit-clip-path: polygon(0% 0%, 0% 77%, 100% 34%, 100% -44%);
-    clip-path: polygon(0% 0%, 0% 77%, 100% 34%, 100% -44%);
+  0%, 71% {
+    -webkit-clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -44%);
+    clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -44%);
   }
 
-  95% {
+  96%, 100% {
     -webkit-clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -44%);
     clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -44%);
   }
@@ -32,32 +32,31 @@ exports[`LogomarkSpinner renders a white spinner 1`] = `
 }
 
 .emotion-0 {
-  position: relative;
+  height: 100px;
   width: 100px;
 }
 
 .emotion-1 {
-  padding-top: 100%;
+  -webkit-animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
+  animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
+  margin: auto;
+  width: 76.65%;
+  will-change: clip-path;
 }
 
 .emotion-2 {
-  -webkit-animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
-  animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
-  bottom: 0;
-  left: 11.675%;
-  position: absolute;
-  right: 11.675%;
-  top: 0;
+  -webkit-animation: animation-1 cubic-bezier(0, 0, 0.85, 1) 2s infinite alternate;
+  animation: animation-1 cubic-bezier(0, 0, 0.85, 1) 2s infinite alternate;
+  will-change: clip-path;
 }
 
 .emotion-3 {
-  -webkit-animation: animation-1 cubic-bezier(0.3, 0.75, 1, 0.85) 2s infinite alternate;
-  animation: animation-1 cubic-bezier(0.3, 0.75, 1, 0.85) 2s infinite alternate;
+  -webkit-clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
+  clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
 }
 
 .emotion-4 {
-  -webkit-clip-path: polygon(0% -10%, 168.5% 64%, 0% 135%);
-  clip-path: polygon(0% -10%, 168.5% 64%, 0% 135%);
+  display: block;
 }
 
 .emotion-5 {
@@ -65,6 +64,7 @@ exports[`LogomarkSpinner renders a white spinner 1`] = `
   animation: animation-2 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
   stroke-dasharray: 9800;
   stroke-dashoffset: 9800;
+  will-change: stroke-dashoffset;
 }
 
 <div
@@ -79,28 +79,25 @@ exports[`LogomarkSpinner renders a white spinner 1`] = `
       <div
         class="emotion-3"
       >
-        <div
+        <svg
           class="emotion-4"
+          version="1.1"
+          viewBox="0 0 2640 3444"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
         >
-          <svg
-            version="1.1"
-            viewBox="0 0 2640 3444"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <title>
-              Loading
-            </title>
-            <path
-              class="emotion-5"
-              d="M0 0 M2569 1056L143 2447V149l1175 673v1867l1248 715"
-              fill="none"
-              stroke="#ffffff"
-              stroke-linejoin="round"
-              stroke-width="300"
-            />
-          </svg>
-        </div>
+          <title>
+            Loading
+          </title>
+          <path
+            class="emotion-5"
+            d="M0 0 M2569 1056L143 2447V149l1175 673v1867l1248 715"
+            fill="none"
+            stroke="#ffffff"
+            stroke-linejoin="round"
+            stroke-width="300"
+          />
+        </svg>
       </div>
     </div>
   </div>
@@ -109,7 +106,7 @@ exports[`LogomarkSpinner renders a white spinner 1`] = `
 
 exports[`LogomarkSpinner renders with a custom size 1`] = `
 @keyframes animation-0 {
-  5% {
+  0%, 6% {
     -webkit-clip-path: polygon(0% -12%, 0% -12%, 169% 63%, 169% 63%);
     clip-path: polygon(0% -12%, 0% -12%, 169% 63%, 169% 63%);
   }
@@ -121,12 +118,12 @@ exports[`LogomarkSpinner renders with a custom size 1`] = `
 }
 
 @keyframes animation-1 {
-  71% {
-    -webkit-clip-path: polygon(0% 0%, 0% 77%, 100% 34%, 100% -44%);
-    clip-path: polygon(0% 0%, 0% 77%, 100% 34%, 100% -44%);
+  0%, 71% {
+    -webkit-clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -44%);
+    clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -44%);
   }
 
-  95% {
+  96%, 100% {
     -webkit-clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -44%);
     clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -44%);
   }
@@ -139,32 +136,31 @@ exports[`LogomarkSpinner renders with a custom size 1`] = `
 }
 
 .emotion-0 {
-  position: relative;
+  height: 200px;
   width: 200px;
 }
 
 .emotion-1 {
-  padding-top: 100%;
+  -webkit-animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
+  animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
+  margin: auto;
+  width: 76.65%;
+  will-change: clip-path;
 }
 
 .emotion-2 {
-  -webkit-animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
-  animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
-  bottom: 0;
-  left: 11.675%;
-  position: absolute;
-  right: 11.675%;
-  top: 0;
+  -webkit-animation: animation-1 cubic-bezier(0, 0, 0.85, 1) 2s infinite alternate;
+  animation: animation-1 cubic-bezier(0, 0, 0.85, 1) 2s infinite alternate;
+  will-change: clip-path;
 }
 
 .emotion-3 {
-  -webkit-animation: animation-1 cubic-bezier(0.3, 0.75, 1, 0.85) 2s infinite alternate;
-  animation: animation-1 cubic-bezier(0.3, 0.75, 1, 0.85) 2s infinite alternate;
+  -webkit-clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
+  clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
 }
 
 .emotion-4 {
-  -webkit-clip-path: polygon(0% -10%, 168.5% 64%, 0% 135%);
-  clip-path: polygon(0% -10%, 168.5% 64%, 0% 135%);
+  display: block;
 }
 
 .emotion-5 {
@@ -172,6 +168,7 @@ exports[`LogomarkSpinner renders with a custom size 1`] = `
   animation: animation-2 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
   stroke-dasharray: 9800;
   stroke-dashoffset: 9800;
+  will-change: stroke-dashoffset;
 }
 
 <div
@@ -186,28 +183,25 @@ exports[`LogomarkSpinner renders with a custom size 1`] = `
       <div
         class="emotion-3"
       >
-        <div
+        <svg
           class="emotion-4"
+          version="1.1"
+          viewBox="0 0 2640 3444"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
         >
-          <svg
-            version="1.1"
-            viewBox="0 0 2640 3444"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <title>
-              Loading
-            </title>
-            <path
-              class="emotion-5"
-              d="M0 0 M2569 1056L143 2447V149l1175 673v1867l1248 715"
-              fill="none"
-              stroke="#05192d"
-              stroke-linejoin="round"
-              stroke-width="300"
-            />
-          </svg>
-        </div>
+          <title>
+            Loading
+          </title>
+          <path
+            class="emotion-5"
+            d="M0 0 M2569 1056L143 2447V149l1175 673v1867l1248 715"
+            fill="none"
+            stroke="#05192d"
+            stroke-linejoin="round"
+            stroke-width="300"
+          />
+        </svg>
       </div>
     </div>
   </div>
@@ -216,7 +210,7 @@ exports[`LogomarkSpinner renders with a custom size 1`] = `
 
 exports[`LogomarkSpinner renders with default props 1`] = `
 @keyframes animation-0 {
-  5% {
+  0%, 6% {
     -webkit-clip-path: polygon(0% -12%, 0% -12%, 169% 63%, 169% 63%);
     clip-path: polygon(0% -12%, 0% -12%, 169% 63%, 169% 63%);
   }
@@ -228,12 +222,12 @@ exports[`LogomarkSpinner renders with default props 1`] = `
 }
 
 @keyframes animation-1 {
-  71% {
-    -webkit-clip-path: polygon(0% 0%, 0% 77%, 100% 34%, 100% -44%);
-    clip-path: polygon(0% 0%, 0% 77%, 100% 34%, 100% -44%);
+  0%, 71% {
+    -webkit-clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -44%);
+    clip-path: polygon(0% 0%, 0% 78.5%, 100% 34.5%, 100% -44%);
   }
 
-  95% {
+  96%, 100% {
     -webkit-clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -44%);
     clip-path: polygon(0% 0%, 0% 140%, 100% 96%, 100% -44%);
   }
@@ -246,32 +240,31 @@ exports[`LogomarkSpinner renders with default props 1`] = `
 }
 
 .emotion-0 {
-  position: relative;
+  height: 100px;
   width: 100px;
 }
 
 .emotion-1 {
-  padding-top: 100%;
+  -webkit-animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
+  animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
+  margin: auto;
+  width: 76.65%;
+  will-change: clip-path;
 }
 
 .emotion-2 {
-  -webkit-animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
-  animation: animation-0 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
-  bottom: 0;
-  left: 11.675%;
-  position: absolute;
-  right: 11.675%;
-  top: 0;
+  -webkit-animation: animation-1 cubic-bezier(0, 0, 0.85, 1) 2s infinite alternate;
+  animation: animation-1 cubic-bezier(0, 0, 0.85, 1) 2s infinite alternate;
+  will-change: clip-path;
 }
 
 .emotion-3 {
-  -webkit-animation: animation-1 cubic-bezier(0.3, 0.75, 1, 0.85) 2s infinite alternate;
-  animation: animation-1 cubic-bezier(0.3, 0.75, 1, 0.85) 2s infinite alternate;
+  -webkit-clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
+  clip-path: polygon(-0.1% -10%, 169% 65%, -0.1% 139%);
 }
 
 .emotion-4 {
-  -webkit-clip-path: polygon(0% -10%, 168.5% 64%, 0% 135%);
-  clip-path: polygon(0% -10%, 168.5% 64%, 0% 135%);
+  display: block;
 }
 
 .emotion-5 {
@@ -279,6 +272,7 @@ exports[`LogomarkSpinner renders with default props 1`] = `
   animation: animation-2 cubic-bezier(0.65, 0, 0.55, 1) 2s infinite alternate;
   stroke-dasharray: 9800;
   stroke-dashoffset: 9800;
+  will-change: stroke-dashoffset;
 }
 
 <div
@@ -293,28 +287,25 @@ exports[`LogomarkSpinner renders with default props 1`] = `
       <div
         class="emotion-3"
       >
-        <div
+        <svg
           class="emotion-4"
+          version="1.1"
+          viewBox="0 0 2640 3444"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
         >
-          <svg
-            version="1.1"
-            viewBox="0 0 2640 3444"
-            xmlns="http://www.w3.org/2000/svg"
-            xmlns:xlink="http://www.w3.org/1999/xlink"
-          >
-            <title>
-              Loading
-            </title>
-            <path
-              class="emotion-5"
-              d="M0 0 M2569 1056L143 2447V149l1175 673v1867l1248 715"
-              fill="none"
-              stroke="#05192d"
-              stroke-linejoin="round"
-              stroke-width="300"
-            />
-          </svg>
-        </div>
+          <title>
+            Loading
+          </title>
+          <path
+            class="emotion-5"
+            d="M0 0 M2569 1056L143 2447V149l1175 673v1867l1248 715"
+            fill="none"
+            stroke="#05192d"
+            stroke-linejoin="round"
+            stroke-width="300"
+          />
+        </svg>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What has been done
- position loader svg as block
- tweak numbers for this positioning
- simplify the loader container

### Notes
- the inline positioning of the svg had a different relative effect at different sizes, changing some of the proportions the animations are based on at some sizes