### PR TITLE
[WF-489] Add Props table

### DIFF
--- a/packages/docs/next-doc-site/components/code-preview.tsx
+++ b/packages/docs/next-doc-site/components/code-preview.tsx
@@ -3,6 +3,7 @@ import { border, colors } from '@datacamp/waffles-tokens';
 import { css } from '@emotion/react';
 
 const wrapperStyle = css`
+  position: relative;
   padding: 16px;
   background-color: ${colors.navy};
   border-bottom-left-radius: ${border.radius};

--- a/packages/docs/next-doc-site/components/code-preview.tsx
+++ b/packages/docs/next-doc-site/components/code-preview.tsx
@@ -1,9 +1,6 @@
 // eslint-disable-next-line filenames/match-exported
 import { border, colors } from '@datacamp/waffles-tokens';
 import { css } from '@emotion/react';
-import Highlight, { defaultProps } from 'prism-react-renderer';
-
-import theme from './code-preview-theme';
 
 const wrapperStyle = css`
   padding: 16px;
@@ -11,34 +8,18 @@ const wrapperStyle = css`
   border-bottom-left-radius: ${border.radius};
   border-bottom-right-radius: ${border.radius};
   border-left: 8px solid ${colors.purple};
-  overflow-x: scroll;
+  overflow: hidden;
 `;
 
 type CodePreviewProps = {
-  children: string;
+  children: React.ReactNode;
+  className?: string;
 };
 
-function CodePreview({ children }: CodePreviewProps): JSX.Element {
+function CodePreview({ children, className }: CodePreviewProps): JSX.Element {
   return (
-    <div css={wrapperStyle}>
-      <Highlight
-        {...defaultProps}
-        code={children.trim()}
-        language="tsx"
-        theme={theme}
-      >
-        {({ getLineProps, getTokenProps, style, tokens }) => (
-          <pre style={{ ...style }}>
-            {tokens.map((line, index) => (
-              <div key={index} {...getLineProps({ key: index, line })}>
-                {line.map((token, key) => (
-                  <span key={key} {...getTokenProps({ key, token })} />
-                ))}
-              </div>
-            ))}
-          </pre>
-        )}
-      </Highlight>
+    <div className={className} css={wrapperStyle}>
+      {children}
     </div>
   );
 }

--- a/packages/docs/next-doc-site/components/colors-grid.tsx
+++ b/packages/docs/next-doc-site/components/colors-grid.tsx
@@ -1,0 +1,103 @@
+// eslint-disable-next-line filenames/match-exported
+import {
+  border,
+  colors as colorTokens,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+} from '@datacamp/waffles-tokens';
+import { css } from '@emotion/react';
+import { readableColor } from 'polished';
+import { Fragment } from 'react';
+
+import colorItemsPerRow from '../helpers/color-items-per-row';
+import colorsFromTokens from '../helpers/colors-from-tokens';
+
+import Markdown from './markdown-elements';
+
+const wrapperStyle = css`
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  border-radius: ${border.radius};
+  overflow: hidden;
+  margin-top: 8px;
+`;
+
+const itemStyle = css`
+  height: 100px;
+  padding: 16px;
+`;
+
+const itemLabelStyle = css`
+  font-family: ${fontFamily.sansSerif};
+  font-size: ${fontSize.h6};
+  line-height: ${lineHeight.base};
+`;
+
+const MAX_ITEMS_PER_ROW = 4;
+
+type ColorGridProps = {
+  category: string;
+  colors: Array<keyof typeof colorTokens>;
+};
+
+function ColorsGrid({ category, colors }: ColorGridProps): JSX.Element {
+  const pickedColors = colorsFromTokens(colors, colorTokens);
+
+  return (
+    <Fragment>
+      <Markdown.h3>{category}</Markdown.h3>
+      <ul css={wrapperStyle}>
+        {pickedColors.map((color, index) => {
+          const labelColor = readableColor(
+            color.value,
+            colorTokens.navyText,
+            colorTokens.white,
+          );
+          const denominator = colorItemsPerRow(
+            pickedColors.length,
+            index,
+            MAX_ITEMS_PER_ROW,
+          );
+
+          return (
+            <li
+              css={css`
+                ${itemStyle}
+                background-color: ${color.value};
+                color: ${labelColor};
+                width: calc(100% / ${denominator});
+              `}
+              key={`${color.name}-${index}`}
+            >
+              <div
+                css={css`
+                  ${itemLabelStyle}
+                  text-transform: capitalize;
+                  font-weight: ${fontWeight.bold};
+                  color: ${labelColor};
+                `}
+              >
+                {color.name}
+              </div>
+              <div
+                css={css`
+                  ${itemLabelStyle}
+                  color: ${labelColor};
+                `}
+              >
+                {color.value}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </Fragment>
+  );
+}
+
+export default ColorsGrid;

--- a/packages/docs/next-doc-site/components/download-button.tsx
+++ b/packages/docs/next-doc-site/components/download-button.tsx
@@ -1,0 +1,64 @@
+// eslint-disable-next-line filenames/match-exported
+import { DownloadIcon } from '@datacamp/waffles-icons';
+import {
+  border,
+  colors,
+  fontFamily,
+  fontSize,
+  fontWeight,
+} from '@datacamp/waffles-tokens';
+import { css } from '@emotion/react';
+
+import { A11Y_COLOR } from './constants';
+
+const buttonStyle = css`
+  display: inline-flex;
+  padding: 0 18px 0 16px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  color: ${colors.white};
+  background-color: ${colors.navy};
+  font-family: ${fontFamily.sansSerif};
+  border-radius: ${border.radius};
+  font-size: ${fontSize.h6};
+  font-weight: ${fontWeight.bold};
+  text-decoration: none;
+  cursor: pointer;
+  margin-top: 8px;
+  outline: 0;
+
+  &:hover {
+    background-color: ${colors.navyLight};
+  }
+
+  &:focus-visible {
+    background-color: ${A11Y_COLOR};
+  }
+`;
+
+const labelStyle = css`
+  padding-left: 8px;
+`;
+
+type DownloadButtonProps = {
+  children: React.ReactNode;
+  download: string;
+  href: string;
+};
+
+function DownloadButton({
+  children,
+  download,
+  href,
+}: DownloadButtonProps): JSX.Element {
+  return (
+    <a css={buttonStyle} download={download} href={href}>
+      <DownloadIcon />
+      <span css={labelStyle}>{children}</span>
+    </a>
+  );
+}
+
+export default DownloadButton;

--- a/packages/docs/next-doc-site/components/editor.tsx
+++ b/packages/docs/next-doc-site/components/editor.tsx
@@ -1,0 +1,44 @@
+/* eslint-disable no-shadow */
+import { Fragment } from 'react';
+import SimpleEditor from 'react-simple-code-editor';
+import { TEditorProps, useValueDebounce } from 'react-view';
+
+import basicTheme from './code-preview-theme';
+import Highlight from './highlight';
+
+const editorTheme = {
+  ...basicTheme,
+  plain: {
+    whiteSpace: 'break-spaces',
+    ...basicTheme.plain,
+  },
+};
+
+function Editor({
+  code: globalCode = '',
+  onChange,
+  placeholder,
+}: TEditorProps): JSX.Element {
+  // const [focused, setFocused] = React.useState(false);
+  const [code, setCode] = useValueDebounce<string>(globalCode, onChange);
+
+  return (
+    <Fragment>
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `.npm__react-simple-code-editor__textarea { outline: none !important }`,
+        }}
+      />
+      <SimpleEditor
+        highlight={(code) => <Highlight theme={editorTheme}>{code}</Highlight>}
+        ignoreTabKey={true}
+        onValueChange={(code) => setCode(code)}
+        placeholder={placeholder}
+        style={editorTheme.plain as React.CSSProperties}
+        value={code}
+      />
+    </Fragment>
+  );
+}
+
+export default Editor;

--- a/packages/docs/next-doc-site/components/editor.tsx
+++ b/packages/docs/next-doc-site/components/editor.tsx
@@ -14,12 +14,16 @@ const editorTheme = {
   },
 };
 
+type EditorProps = {
+  setIsFocused: (isFocused: boolean) => void;
+} & TEditorProps;
+
 function Editor({
   code: globalCode = '',
   onChange,
   placeholder,
-}: TEditorProps): JSX.Element {
-  // const [focused, setFocused] = React.useState(false);
+  setIsFocused,
+}: EditorProps): JSX.Element {
   const [code, setCode] = useValueDebounce<string>(globalCode, onChange);
 
   return (
@@ -32,6 +36,8 @@ function Editor({
       <SimpleEditor
         highlight={(code) => <Highlight theme={editorTheme}>{code}</Highlight>}
         ignoreTabKey={true}
+        onBlur={() => setIsFocused(false)}
+        onFocus={() => setIsFocused(true)}
         onValueChange={(code) => setCode(code)}
         placeholder={placeholder}
         style={editorTheme.plain as React.CSSProperties}

--- a/packages/docs/next-doc-site/components/example.tsx
+++ b/packages/docs/next-doc-site/components/example.tsx
@@ -5,6 +5,8 @@ import { useEffect, useState } from 'react';
 
 import CodePreview from './code-preview';
 import Button from './code-preview-button';
+import basicTheme from './code-preview-theme';
+import Highlight from './highlight';
 import Markdown from './markdown-elements';
 
 const sectionStyle = css`
@@ -26,6 +28,10 @@ const buttonStyle = css`
   position: absolute;
   bottom: 0;
   right: 0;
+`;
+
+const previewStyle = css`
+  overflow-x: scroll;
 `;
 
 type ExampleProps = {
@@ -79,7 +85,11 @@ function Example({ children, path, title }: ExampleProps): JSX.Element {
           {isCodePreviewVisible ? 'Hide' : 'Show'} Code
         </Button>
       </div>
-      {code && isCodePreviewVisible && <CodePreview>{code}</CodePreview>}
+      {code && isCodePreviewVisible && (
+        <CodePreview css={previewStyle}>
+          <Highlight theme={basicTheme}>{code.trim()}</Highlight>
+        </CodePreview>
+      )}
     </section>
   );
 }

--- a/packages/docs/next-doc-site/components/highlight.tsx
+++ b/packages/docs/next-doc-site/components/highlight.tsx
@@ -1,0 +1,39 @@
+import HighlightBase, { defaultProps } from 'prism-react-renderer';
+
+import basicTheme from './code-preview-theme';
+
+type HighlightProps = {
+  children: string;
+  theme: typeof basicTheme;
+};
+
+function Highlight({ children, theme }: HighlightProps): JSX.Element {
+  return (
+    <HighlightBase
+      {...defaultProps}
+      code={children}
+      language="tsx"
+      theme={theme}
+    >
+      {({ getLineProps, getTokenProps, style, tokens }) => {
+        return (
+          <pre style={{ ...style }}>
+            {tokens.map((line, index) => {
+              return (
+                <div key={index} {...getLineProps({ key: index, line })}>
+                  {line.map((token, key) => {
+                    return (
+                      <span key={key} {...getTokenProps({ key, token })} />
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </pre>
+        );
+      }}
+    </HighlightBase>
+  );
+}
+
+export default Highlight;

--- a/packages/docs/next-doc-site/components/icons-grid.tsx
+++ b/packages/docs/next-doc-site/components/icons-grid.tsx
@@ -1,0 +1,81 @@
+// eslint-disable-next-line filenames/match-exported
+import * as allIcons from '@datacamp/waffles-icons';
+import { border, colors } from '@datacamp/waffles-tokens';
+import { css } from '@emotion/react';
+
+const brandIcons = Object.entries(allIcons)
+  .filter((icon) => {
+    const [name] = icon;
+    return /BrandIcon$/.test(name);
+  })
+  .map((iconData) => iconData[1]);
+
+const invertedIcons = Object.entries(allIcons)
+  .filter((icon) => {
+    const [name] = icon;
+    return /InvertedIcon$/.test(name);
+  })
+  .map((iconData) => iconData[1]);
+
+const regularIcons = Object.entries(allIcons)
+  .filter((icon) => {
+    const [name] = icon;
+    return !/InvertedIcon|BrandIcon$/.test(name);
+  })
+  .map((iconData) => iconData[1]);
+
+const wrapperStyle = css`
+  display: flex;
+  flex-wrap: wrap;
+  border: 1px solid ${colors.beige400};
+  margin-top: 8px;
+  padding: 8px;
+  width: 100%;
+  border-radius: ${border.radius};
+`;
+
+const iconStyle = css`
+  margin: 8px;
+`;
+
+type IconsGridProps = {
+  variant: 'regular' | 'inverted' | 'brand';
+};
+
+function IconsGrid({ variant }: IconsGridProps): JSX.Element {
+  function renderIcons(icons: typeof regularIcons): JSX.Element {
+    return (
+      <div
+        css={css`
+          ${wrapperStyle}
+          ${variant === 'inverted' &&
+          css`
+            border: none;
+          `};
+          background-color: ${variant === 'inverted'
+            ? colors.navyLight
+            : 'transparent'};
+        `}
+      >
+        {icons.map((Icon, index) => (
+          <Icon
+            color={variant === 'inverted' ? colors.white : colors.navyDark}
+            css={iconStyle}
+            key={`$icon-${index}`}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (variant === 'inverted') {
+    return renderIcons(invertedIcons);
+  }
+  if (variant === 'brand') {
+    return renderIcons(brandIcons);
+  }
+
+  return renderIcons(regularIcons);
+}
+
+export default IconsGrid;

--- a/packages/docs/next-doc-site/components/icons-grid.tsx
+++ b/packages/docs/next-doc-site/components/icons-grid.tsx
@@ -43,23 +43,23 @@ type IconsGridProps = {
 };
 
 function IconsGrid({ variant }: IconsGridProps): JSX.Element {
+  const isInverted = variant === 'inverted';
+
   function renderIcons(icons: typeof regularIcons): JSX.Element {
     return (
       <div
         css={css`
           ${wrapperStyle}
-          ${variant === 'inverted' &&
+          ${isInverted &&
           css`
             border: none;
           `};
-          background-color: ${variant === 'inverted'
-            ? colors.navyLight
-            : 'transparent'};
+          background-color: ${isInverted ? colors.navyLight : 'transparent'};
         `}
       >
         {icons.map((Icon, index) => (
           <Icon
-            color={variant === 'inverted' ? colors.white : colors.navyDark}
+            color={isInverted ? colors.white : colors.navyDark}
             css={iconStyle}
             key={`$icon-${index}`}
           />

--- a/packages/docs/next-doc-site/components/playground.tsx
+++ b/packages/docs/next-doc-site/components/playground.tsx
@@ -3,12 +3,13 @@ import { BackIcon } from '@datacamp/waffles-icons';
 import { border, colors, fontFamily, fontSize } from '@datacamp/waffles-tokens';
 import { css } from '@emotion/react';
 import { Fragment } from 'react';
-import { Compiler, Editor, Error, useView } from 'react-view';
+import { Compiler, Error, useView } from 'react-view';
 
 import { PlaygroundConfig } from '../types';
 
+import CodePreview from './code-preview';
 import Button from './code-preview-button';
-import theme from './code-preview-theme';
+import Editor from './editor';
 
 const wrapperStyle = css`
   position: relative;
@@ -28,12 +29,6 @@ const buttonStyle = css`
   bottom: 0;
   border-radius: 0;
   border-top-left-radius: ${border.radius};
-`;
-
-const editorStyle = css`
-  background-color: ${colors.navy};
-  border-left: 8px solid ${colors.purple};
-  padding: 8px;
 `;
 
 const errorStyle = css`
@@ -73,16 +68,15 @@ function Playground({ initialCode, scope }: PlaygroundConfig): JSX.Element {
           Reset
         </Button>
       </div>
-      <Editor
-        {...editorProps}
+      <CodePreview
         css={css`
-          ${editorStyle}
           border-bottom-left-radius: ${hasError ? 0 : border.radius};
           border-bottom-right-radius: ${hasError ? 0 : border.radius};
         `}
-        language="tsx"
-        theme={theme}
-      />
+      >
+        <Editor {...editorProps} />
+      </CodePreview>
+
       <Error {...errorProps} css={errorStyle} />
     </Fragment>
   );

--- a/packages/docs/next-doc-site/components/playground.tsx
+++ b/packages/docs/next-doc-site/components/playground.tsx
@@ -2,7 +2,7 @@ import presetTypescript from '@babel/preset-typescript';
 import { BackIcon } from '@datacamp/waffles-icons';
 import { border, colors, fontFamily, fontSize } from '@datacamp/waffles-tokens';
 import { css } from '@emotion/react';
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import { Compiler, Error, useView } from 'react-view';
 
 import { PlaygroundConfig } from '../types';
@@ -43,12 +43,27 @@ const errorStyle = css`
   overflow: hidden;
 `;
 
+const liveLabelStyle = css`
+  opacity: 0.5;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  color: ${colors.grey200};
+  font-family: ${fontFamily.sansSerif};
+  font-size: ${fontSize.small};
+  text-transform: uppercase;
+  user-select: none;
+  padding: 8px 12px;
+`;
+
 function Playground({ initialCode, scope }: PlaygroundConfig): JSX.Element {
   const { actions, compilerProps, editorProps, errorProps } = useView({
     initialCode: initialCode.trim(),
     scope,
   });
   const { reset } = actions;
+
+  const [isEditorFocused, setIsEditorFocused] = useState(false);
 
   const hasError = !!errorProps.msg;
 
@@ -72,9 +87,18 @@ function Playground({ initialCode, scope }: PlaygroundConfig): JSX.Element {
         css={css`
           border-bottom-left-radius: ${hasError ? 0 : border.radius};
           border-bottom-right-radius: ${hasError ? 0 : border.radius};
+          border-left-color: ${isEditorFocused ? colors.green : colors.purple};
         `}
       >
-        <Editor {...editorProps} />
+        <Editor {...editorProps} setIsFocused={setIsEditorFocused} />
+        <span
+          css={css`
+            ${liveLabelStyle}
+            opacity: ${isEditorFocused ? 1 : 0.5};
+          `}
+        >
+          Live
+        </span>
       </CodePreview>
 
       <Error {...errorProps} css={errorStyle} />

--- a/packages/docs/next-doc-site/components/props-table.tsx
+++ b/packages/docs/next-doc-site/components/props-table.tsx
@@ -1,29 +1,41 @@
 // eslint-disable-next-line filenames/match-exported
-import metadata from '@datacamp/waffles-text/componentMetadata.json';
+import { colors } from '@datacamp/waffles-tokens';
+import { css } from '@emotion/react';
 import { Fragment } from 'react';
 
 import componentMetadataByName from '../helpers/component-metadata-by-name';
 import typeNameFromMetadata from '../helpers/type-name-from-metadata';
+import { Metadata } from '../types';
 
 import Markdown from './markdown-elements';
+import Table from './table';
+
+const requiredStyle = css`
+  color: ${colors.redText};
+`;
+
+const descriptionStyle = css`
+  min-width: 300px;
+`;
 
 type PropsTableProps = {
   componentName: string;
+  metadata: Metadata;
 };
 
-function PropsTable({ componentName }: PropsTableProps): JSX.Element {
+function PropsTable({ componentName, metadata }: PropsTableProps): JSX.Element {
   const data = componentMetadataByName(metadata, componentName);
 
   return (
     <Fragment>
       <Markdown.h3>{componentName}</Markdown.h3>
-      <table>
+      <Table>
         <thead>
           <tr>
-            <th>Name</th>
-            <th>Value</th>
-            <th>Default</th>
-            <th>Description</th>
+            <Table.HeadCell>Name</Table.HeadCell>
+            <Table.HeadCell>Value</Table.HeadCell>
+            <Table.HeadCell>Default</Table.HeadCell>
+            <Table.HeadCell>Description</Table.HeadCell>
           </tr>
         </thead>
         <tbody>
@@ -32,19 +44,23 @@ function PropsTable({ componentName }: PropsTableProps): JSX.Element {
               const [name, propData] = prop;
               return (
                 <tr key={`prop-${name}`}>
-                  <td>{name === 'innerRef' ? 'ref' : name}</td>
-                  <td>{typeNameFromMetadata(propData)}</td>
-                  <td>
-                    {propData.required
-                      ? 'Required'
-                      : propData.defaultValue?.value}
-                  </td>
-                  <td>{data.description}</td>
+                  <Table.Cell>{name === 'innerRef' ? 'ref' : name}</Table.Cell>
+                  <Table.Cell>{typeNameFromMetadata(propData)}</Table.Cell>
+                  <Table.Cell>
+                    {propData.required ? (
+                      <span css={requiredStyle}>Required</span>
+                    ) : (
+                      propData.defaultValue?.value
+                    )}
+                  </Table.Cell>
+                  <Table.Cell css={descriptionStyle}>
+                    {propData.description}
+                  </Table.Cell>
                 </tr>
               );
             })}
         </tbody>
-      </table>
+      </Table>
     </Fragment>
   );
 }

--- a/packages/docs/next-doc-site/components/props-table.tsx
+++ b/packages/docs/next-doc-site/components/props-table.tsx
@@ -1,0 +1,52 @@
+// eslint-disable-next-line filenames/match-exported
+import metadata from '@datacamp/waffles-text/componentMetadata.json';
+import { Fragment } from 'react';
+
+import componentMetadataByName from '../helpers/component-metadata-by-name';
+import typeNameFromMetadata from '../helpers/type-name-from-metadata';
+
+import Markdown from './markdown-elements';
+
+type PropsTableProps = {
+  componentName: string;
+};
+
+function PropsTable({ componentName }: PropsTableProps): JSX.Element {
+  const data = componentMetadataByName(metadata, componentName);
+
+  return (
+    <Fragment>
+      <Markdown.h3>{componentName}</Markdown.h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Value</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data?.props &&
+            Object.entries(data.props).map((prop) => {
+              const [name, propData] = prop;
+              return (
+                <tr key={`prop-${name}`}>
+                  <td>{name === 'innerRef' ? 'ref' : name}</td>
+                  <td>{typeNameFromMetadata(propData)}</td>
+                  <td>
+                    {propData.required
+                      ? 'Required'
+                      : propData.defaultValue?.value}
+                  </td>
+                  <td>{data.description}</td>
+                </tr>
+              );
+            })}
+        </tbody>
+      </table>
+    </Fragment>
+  );
+}
+
+export default PropsTable;

--- a/packages/docs/next-doc-site/components/table.tsx
+++ b/packages/docs/next-doc-site/components/table.tsx
@@ -1,0 +1,86 @@
+import {
+  border,
+  colors,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+} from '@datacamp/waffles-tokens';
+import { css } from '@emotion/react';
+
+const wrapperStyle = css`
+  border: 1px solid ${colors.beige400};
+  border-radius: ${border.radius};
+  margin-top: 8px;
+  overflow-x: scroll;
+`;
+
+const tableStyle = css`
+  width: 100%;
+  background-color: ${colors.white};
+  color: ${colors.navyText};
+  font-family: ${fontFamily.sansSerif};
+  font-size: ${fontSize.h6};
+  font-weight: ${fontWeight.regular};
+  line-height: ${lineHeight.base};
+  border-collapse: collapse;
+`;
+
+const tableCellStyle = css`
+  padding: 16px;
+  text-align: left;
+  border-top: 1px solid ${colors.beige400};
+  word-wrap: break-word;
+  vertical-align: top;
+
+  &:first-of-type {
+    font-weight: ${fontWeight.bold};
+  }
+`;
+
+const tableHeadCellStyle = css`
+  font-size: ${fontSize.small};
+  font-weight: ${fontWeight.bold};
+  text-transform: uppercase;
+  border-top: none;
+  min-width: 140px;
+  letter-spacing: 1px;
+`;
+
+type TableCellProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+function TableCell({ children, className }: TableCellProps): JSX.Element {
+  return (
+    <td className={className} css={tableCellStyle}>
+      {children}
+    </td>
+  );
+}
+
+function TableHeadCell({ children, className }: TableCellProps): JSX.Element {
+  return (
+    <td className={className} css={[tableCellStyle, tableHeadCellStyle]}>
+      {children}
+    </td>
+  );
+}
+
+type TableProps = {
+  children: React.ReactNode;
+};
+
+function Table({ children }: TableProps): JSX.Element {
+  return (
+    <div css={wrapperStyle}>
+      <table css={tableStyle}>{children}</table>
+    </div>
+  );
+}
+
+Table.Cell = TableCell;
+Table.HeadCell = TableHeadCell;
+
+export default Table;

--- a/packages/docs/next-doc-site/helpers/color-items-per-row.ts
+++ b/packages/docs/next-doc-site/helpers/color-items-per-row.ts
@@ -1,0 +1,13 @@
+// eslint-disable-next-line filenames/match-exported
+function colorItemsPerRow(
+  numberOfColors: number,
+  currentItemIndex: number,
+  maxItemsPerRow: number,
+): number {
+  const numberOfColorsInFirstRow = numberOfColors % maxItemsPerRow;
+  return currentItemIndex < numberOfColorsInFirstRow
+    ? numberOfColorsInFirstRow
+    : maxItemsPerRow;
+}
+
+export default colorItemsPerRow;

--- a/packages/docs/next-doc-site/helpers/colors-from-tokens.ts
+++ b/packages/docs/next-doc-site/helpers/colors-from-tokens.ts
@@ -1,0 +1,23 @@
+// eslint-disable-next-line filenames/match-exported
+type Color = {
+  name: string;
+  value: string;
+};
+
+type ColorTokens = {
+  [key: string]: string;
+};
+
+function colorsFromTokens(colors: string[], colorTokens: ColorTokens): Color[] {
+  return colors.reduce<Color[]>((pickedColors, currentColor) => {
+    if (colorTokens[currentColor]) {
+      return pickedColors.concat({
+        name: currentColor,
+        value: colorTokens[currentColor],
+      });
+    }
+    return pickedColors;
+  }, []);
+}
+
+export default colorsFromTokens;

--- a/packages/docs/next-doc-site/helpers/component-metadata-by-name.ts
+++ b/packages/docs/next-doc-site/helpers/component-metadata-by-name.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line filenames/match-exported
+import { Metadata, SingleComponentMetadata } from '../types';
+
+function componentMetadataByName(
+  metadata: Metadata,
+  name: string,
+): SingleComponentMetadata | undefined {
+  const data = Object.values(metadata).find(
+    (item) => item[0].displayName === name,
+  );
+  return data && data[0];
+}
+
+export default componentMetadataByName;

--- a/packages/docs/next-doc-site/helpers/type-name-from-metadata.ts
+++ b/packages/docs/next-doc-site/helpers/type-name-from-metadata.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line filenames/match-exported
 import { PropMetadata } from '../types';
 
-// It's pretty dirty, but in future we won't it
+// For now it's pretty dirty, but in future we won't need it
 function typeNameFromMetadata(prop: PropMetadata): string {
   // First try type from propTypes
   if (prop.type) {

--- a/packages/docs/next-doc-site/helpers/type-name-from-metadata.ts
+++ b/packages/docs/next-doc-site/helpers/type-name-from-metadata.ts
@@ -1,0 +1,45 @@
+// eslint-disable-next-line filenames/match-exported
+import { PropMetadata } from '../types';
+
+// It's pretty dirty, but in future we won't it
+function typeNameFromMetadata(prop: PropMetadata): string {
+  // First try type from propTypes
+  if (prop.type) {
+    const { type } = prop;
+    switch (type.name) {
+      case 'enum': {
+        const value = type.value as Array<{ value: string }>;
+        return value.map((item) => item.value).join(' | ');
+      }
+      case 'union': {
+        const value = type.value as Array<{ name: string }>;
+        return value.map((item) => item.name).join(' | ');
+      }
+      case 'arrayOf': {
+        const value = type.value as { name: string };
+        return `arrayOf(${value.name})`;
+      }
+      case 'func':
+        return 'function';
+      default:
+        return type.name;
+    }
+  }
+
+  // Then try type from typescript
+  if (prop.tsType) {
+    const { tsType } = prop;
+
+    if (tsType.elements) {
+      return tsType.elements
+        .map((element) => element.value || element.name)
+        .join(' | ');
+    }
+
+    return tsType.type || tsType.name;
+  }
+
+  return '⚠️ Unknown type';
+}
+
+export default typeNameFromMetadata;

--- a/packages/docs/next-doc-site/package.json
+++ b/packages/docs/next-doc-site/package.json
@@ -19,6 +19,7 @@
     "@mdx-js/react": "1.6.22",
     "@next/mdx": "10.2.0",
     "next": "10.2.0",
+    "polished": "4.1.2",
     "prism-react-renderer": "1.2.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/packages/docs/next-doc-site/package.json
+++ b/packages/docs/next-doc-site/package.json
@@ -22,6 +22,7 @@
     "prism-react-renderer": "1.2.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",
+    "react-simple-code-editor": "^0.11.0",
     "react-view": "2.3.7"
   },
   "devDependencies": {

--- a/packages/docs/next-doc-site/pages/_document.tsx
+++ b/packages/docs/next-doc-site/pages/_document.tsx
@@ -39,6 +39,13 @@ class CustomDocument extends Document<DocumentInitialProps> {
             rel="preload"
             type="font/woff2"
           />
+          <link
+            as="font"
+            crossOrigin="anonymous"
+            href="https://waffles.datacamp.com/fonts/JetBrainsMono-Regular.woff2"
+            rel="preload"
+            type="font/woff2"
+          />
           <link href="/fonts.css" rel="stylesheet" />
           <style>{`
 *,

--- a/packages/docs/next-doc-site/pages/components/text.mdx
+++ b/packages/docs/next-doc-site/pages/components/text.mdx
@@ -1,8 +1,11 @@
+import metadata from '@datacamp/waffles-text/componentMetadata.json';
+
 import Layout from '../../components/page-layout';
 import Header from '../../components/page-header';
 import Section from '../../components/page-section';
 import Example from '../../components/example';
 import Playground from '../../components/playground';
+import PropsTable from '../../components/props-table';
 
 import playgroundConfig from '../../examples/text/playground-config';
 import Paragraph from '../../examples/text/paragraph';
@@ -38,3 +41,14 @@ Short text components overview.
 </Example>
 
 </Section>
+
+<Section>
+
+## Props
+
+<PropsTable componentName="Text" metadata={metadata} />
+
+<PropsTable componentName="Paragraph" metadata={metadata} />
+
+</Section>
+

--- a/packages/docs/next-doc-site/pages/design/colors.mdx
+++ b/packages/docs/next-doc-site/pages/design/colors.mdx
@@ -1,6 +1,7 @@
 import Layout from '../../components/page-layout';
 import Header from '../../components/page-header';
 import Section from '../../components/page-section';
+import ColorsGrid from '../../components/colors-grid';
 
 export default Layout;
 
@@ -11,24 +12,24 @@ export default Layout;
 
 <Section>
 
-## Section 1
+## Brand Colors
 
-The custom selection of colors. Rejoice #1.
+The DataCamp brand colors are listed below, with their resepective hex codes. If you are wanting to use these colors in an application, check out the tokens package. For more details on usage, check the [full brand guidelines](/).
 
-</Section>
+<ColorsGrid category="Primary" colors={['green', 'navy']} />
 
-<Section>
+<ColorsGrid category="Secondary" colors={['blue', 'red', 'orange', 'purple', 'pink', 'yellow']} />
 
-## Section 2
-
-The custom selection of colors. Rejoice #2.
-
-</Section>
-
-<Section>
-
-## Section 3
-
-The custom selection of colors. Rejoice #3.
+<ColorsGrid category="Neutral" colors={[
+    'beige100',
+    'beige200',
+    'beige300',
+    'beige400',
+    'grey100',
+    'grey200',
+    'grey300',
+    'grey400',
+  ]}
+/>
 
 </Section>

--- a/packages/docs/next-doc-site/pages/design/icons.mdx
+++ b/packages/docs/next-doc-site/pages/design/icons.mdx
@@ -1,6 +1,8 @@
 import Layout from '../../components/page-layout';
 import Header from '../../components/page-header';
 import Section from '../../components/page-section';
+import IconsGrid from '../../components/icons-grid';
+import DownloadButton from '../../components/download-button';
 
 export default Layout;
 
@@ -11,10 +13,47 @@ export default Layout;
 
 <Section>
 
-## Section 1
+## Regular Icons
 
-The custom selection of icons. Rejoice #1.
+<IconsGrid variant="regular" />
 
-We will a lot of text in futere.
+</Section>
+
+<Section>
+
+## Inverted Icons
+
+<IconsGrid variant="inverted" />
+
+</Section>
+
+<Section>
+
+## Brand Icons
+
+<IconsGrid variant="brand" />
+
+</Section>
+
+<Section>
+
+## General Guidelines
+
+### Icon Usage
+
+Our icons are built with purpose and should be used to emphasise context and content. Icons should not be used as ornaments to decorate the page and should not be used at any other size than documented.
+
+If you intend to use the icons within an application, make sure to use the Waffles Icons package.
+For other purposes, you can download it below.
+
+<DownloadButton href="/downloads/icons.zip" download="icons.zip">Download Icons</DownloadButton>
+
+### Convention over Innovation
+
+Some icons are globally accepted as a standard. We should prefer conventions over innovation, for example a cog for settings.
+
+### Pair Icons with Text
+
+The purpose of an icon is to be a visual cue in the interface. There are rare exceptions where icons are universally understood actions, for example the trash icon for deletions.
 
 </Section>

--- a/packages/docs/next-doc-site/pages/index.tsx
+++ b/packages/docs/next-doc-site/pages/index.tsx
@@ -1,8 +1,17 @@
 /* eslint-disable filenames/match-exported */
+import { css } from '@emotion/react';
+
 import Markdown from '../components/markdown-elements';
 import Header from '../components/page-header';
 import Layout from '../components/page-layout';
 import Section from '../components/page-section';
+
+const wrapperStyle = css`
+  width: 100%;
+  min-height: 660px;
+  border: 0;
+  margin-top: 16px;
+`;
 
 function Welcome(): JSX.Element {
   return (
@@ -13,9 +22,14 @@ function Welcome(): JSX.Element {
         pageTitle="Waffles Is DataCamp Design System"
       />
       <Section>
-        <Markdown.h2>New content incoming</Markdown.h2>
-        <Markdown.p>This is the new waffles doc site.</Markdown.p>
-        <Markdown.p>Some extra content below.</Markdown.p>
+        <Markdown.h2>Brand Guidelines</Markdown.h2>
+        <Markdown.p>
+          Please find the full DataCamp brand guidelines below. Check out the
+          rest of this site for information on how to apply these guidelines,
+          and documentation on our library of packages for use in DataCamp
+          applications.
+        </Markdown.p>
+        <iframe css={wrapperStyle} src="/dc_guidelines_dec2020.pdf" />
       </Section>
     </Layout>
   );

--- a/packages/docs/next-doc-site/types.ts
+++ b/packages/docs/next-doc-site/types.ts
@@ -3,3 +3,38 @@ export type PlaygroundConfig = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   scope?: { [key: string]: any };
 };
+
+export type Metadata = {
+  [key: string]: SingleComponentMetadata[];
+};
+
+export type SingleComponentMetadata = {
+  description?: string;
+  displayName: string;
+  props?: {
+    [key: string]: PropMetadata;
+  };
+};
+
+export type PropMetadata = {
+  defaultValue?: {
+    value: string;
+  };
+  description: string;
+  required: boolean;
+  tsType?: {
+    elements?: Array<{
+      name: string;
+      value?: string;
+    }>;
+    name: string;
+    type?: string;
+  };
+  type?: {
+    name: string;
+    value:
+      | Array<{ value: string }>
+      | Array<{ name: string }>
+      | { name: string };
+  };
+};

--- a/packages/react-components/text/src/components/Paragraph.tsx
+++ b/packages/react-components/text/src/components/Paragraph.tsx
@@ -1,13 +1,10 @@
-/* eslint-disable global-require */
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
 import {
-  childrenOfType,
   computeDataAttributes,
   ssrSafeNotFirstChildSelector,
 } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
-import PropTypes from 'prop-types';
-import React, { ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode } from 'react';
 
 import baseStyle from '../baseStyle';
 
@@ -50,30 +47,6 @@ const Paragraph = ({
       {children}
     </p>
   );
-};
-
-const validChildType = PropTypes.oneOfType([
-  childrenOfType(require('./Strong')),
-  childrenOfType(require('./Text')),
-  childrenOfType(require('./Small')),
-  childrenOfType(require('./Emphasis')),
-  childrenOfType(require('./Code')),
-  childrenOfType(require('./Link')),
-  childrenOfType(require('../alternateComponents/AlternateCode')),
-  childrenOfType(require('../alternateComponents/PlainString')),
-  childrenOfType('br'),
-  childrenOfType('del'),
-  childrenOfType('img'),
-  childrenOfType('a'),
-  PropTypes.string,
-  PropTypes.number,
-]);
-
-Paragraph.propTypes = {
-  children: PropTypes.oneOfType([
-    validChildType,
-    PropTypes.arrayOf(validChildType),
-  ]),
 };
 
 export default Paragraph;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1606,6 +1606,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.13.17":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.1.0", "@babel/template@^7.10.4", "@babel/template@^7.12.7", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.7.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc"
@@ -18708,6 +18715,13 @@ pnp-webpack-plugin@1.6.4:
   integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
   dependencies:
     ts-pnp "^1.1.6"
+
+polished@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.1.2.tgz#c04fcc203e287e2d866e9cfcaf102dae1c01a816"
+  integrity sha512-jq4t3PJUpVRcveC53nnbEX35VyQI05x3tniwp26WFdm1dwaNUBHAi5awa/roBlwQxx1uRhwNSYeAi/aMbfiJCQ==
+  dependencies:
+    "@babel/runtime" "^7.13.17"
 
 polished@^3.3.1:
   version "3.4.0"


### PR DESCRIPTION
# [WF-489](https://datacamp.atlassian.net/browse/WF-489), partially [WF-454](https://datacamp.atlassian.net/browse/WF-454)

## Proposed changes
* Implemented **props table component**. It displays props parsed from provided component / module metadata (generated with _react-docgen_).
* Updated **editor** accessibility so it's no longer stuck when pressing Tab key.
* Simplified **Paragrpah** props checks, which was causing problems with MDX
* Added documentation for **Colors** and **Icons** pages

Props table:
![props-table](https://user-images.githubusercontent.com/20565536/117657563-fe549200-b199-11eb-80d3-2cfda7435c3b.jpg)

Colors:
![colors-page](https://user-images.githubusercontent.com/20565536/117853306-89ac5100-b288-11eb-92f9-dd3a745891d7.png)

Icons:
![icons-page](https://user-images.githubusercontent.com/20565536/117853325-8f099b80-b288-11eb-94fd-bcc1104c8a61.png)

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [ ] ~~Unit tests written & pass CI~~
- [ ] ~~Integration tests written & pass CI~~
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [ ] ~~Technical docs written~~
- [ ] ~~Structural changes reflected in Readme~~
- [ ] ~~Migration plan for breaking changes~~

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] ~~Approved by Designer, Engineer, & PO~~
