### PR TITLE
Bundles size optimizations

### DIFF
--- a/packages/other/tokens/package.json
+++ b/packages/other/tokens/package.json
@@ -17,12 +17,12 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "deep-cleaner": "1.2.1",
+    "deep-cleaner": "^1.2.1",
     "jest": "^26.6.1",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "nodemon": "^2.0.7",
     "omit-deep-lodash": "^1.1.5",
-    "style-dictionary": "2.10.2",
+    "style-dictionary": "^2.10.3",
     "tinycolor2": "^1.4.2"
   }
 }

--- a/packages/other/utils/package.json
+++ b/packages/other/utils/package.json
@@ -42,7 +42,6 @@
     "@babel/runtime": "^7.12.1",
     "@types/airbnb-prop-types": "^2.13.1",
     "airbnb-prop-types": "^2.16.0",
-    "lodash": "^4.17.20",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/other/utils/src/computeDataAttributes.ts
+++ b/packages/other/utils/src/computeDataAttributes.ts
@@ -1,12 +1,27 @@
-import { mapKeys } from 'lodash';
+type DataAttributes = {
+  [key: string]: string;
+};
 
 /**
  * Prepends each key of an object with 'data-'
  */
-const computeDataAttributes = (dataAttributes?: {
-  [key: string]: string;
-}): { [key: string]: string } => {
-  return mapKeys(dataAttributes, (_, key) => `data-${key}`);
+const computeDataAttributes = (
+  dataAttributes?: DataAttributes,
+): DataAttributes => {
+  if (!dataAttributes) {
+    return {};
+  }
+
+  return Object.entries(dataAttributes).reduce<DataAttributes>(
+    (updatedEntries, entry) => {
+      const [key, value] = entry;
+      return {
+        ...updatedEntries,
+        [`data-${key}`]: value,
+      };
+    },
+    {},
+  );
 };
 
 export default computeDataAttributes;

--- a/packages/other/utils/src/computeDataAttributes.ts
+++ b/packages/other/utils/src/computeDataAttributes.ts
@@ -12,15 +12,11 @@ const computeDataAttributes = (
     return {};
   }
 
-  return Object.entries(dataAttributes).reduce<DataAttributes>(
-    (updatedEntries, entry) => {
+  return Object.fromEntries(
+    Object.entries(dataAttributes).map((entry) => {
       const [key, value] = entry;
-      return {
-        ...updatedEntries,
-        [`data-${key}`]: value,
-      };
-    },
-    {},
+      return [`data-${key}`, value];
+    }),
   );
 };
 

--- a/packages/other/utils/src/hexToRgbaColor.spec.ts
+++ b/packages/other/utils/src/hexToRgbaColor.spec.ts
@@ -1,0 +1,20 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import hexToRgbaColor from './hexToRgbaColor';
+
+describe('hexToRgbaColor', () => {
+  it('converts HEX color value to RGB counterpart when opacity is not provided', () => {
+    expect(hexToRgbaColor('#0033ff')).toEqual('rgba(0, 51, 255, 1)');
+    expect(hexToRgbaColor('#03f')).toEqual('rgba(0, 51, 255, 1)');
+    expect(hexToRgbaColor('#03ef62')).toEqual('rgba(3, 239, 98, 1)');
+  });
+
+  it('converts HEX color value to RGBA counterpart when opacity is provided', () => {
+    expect(hexToRgbaColor('#0033ff', 0.5)).toEqual('rgba(0, 51, 255, 0.5)');
+    expect(hexToRgbaColor('#03f', 0.5)).toEqual('rgba(0, 51, 255, 0.5)');
+    expect(hexToRgbaColor('#03f', 1)).toEqual('rgba(0, 51, 255, 1)');
+    expect(hexToRgbaColor('#03f', 0)).toEqual('rgba(0, 51, 255, 0)');
+    expect(hexToRgbaColor('#03ef62', 0.3)).toEqual('rgba(3, 239, 98, 0.3)');
+    expect(hexToRgbaColor('#03ef62', 1)).toEqual('rgba(3, 239, 98, 1)');
+    expect(hexToRgbaColor('#03ef62', 0)).toEqual('rgba(3, 239, 98, 0)');
+  });
+});

--- a/packages/other/utils/src/hexToRgbaColor.ts
+++ b/packages/other/utils/src/hexToRgbaColor.ts
@@ -1,0 +1,14 @@
+/**
+ * Converts HEX color to RGBA counterpart, with optional alpha setting
+ */
+const hexToRgbaColor = (hex: string, alpha = 1): string => {
+  const value = hex.slice(1);
+  const group = value.length / 3;
+  return `rgba(${[0, 1, 2]
+    .map((i) => value.slice(i * group, (i + 1) * group))
+    .map((v) => parseInt((v + v).slice(-2), 16).toString())
+    .concat(alpha.toString())
+    .join(', ')})`;
+};
+
+export default hexToRgbaColor;

--- a/packages/other/utils/src/index.spec.ts
+++ b/packages/other/utils/src/index.spec.ts
@@ -1,5 +1,6 @@
 import childrenOfType from './childrenOfType';
 import computeDataAttributes from './computeDataAttributes';
+import hexToRgbaColor from './hexToRgbaColor';
 import isChildType from './isChildType';
 import ssrSafeNotFirstChildSelector from './ssrSafeNotFirstChildSelector';
 
@@ -10,6 +11,7 @@ describe('waffles-utils', () => {
     expect(utils).toEqual({
       childrenOfType,
       computeDataAttributes,
+      hexToRgbaColor,
       isChildType,
       ssrSafeNotFirstChildSelector,
     });

--- a/packages/other/utils/src/index.ts
+++ b/packages/other/utils/src/index.ts
@@ -2,3 +2,4 @@ export { default as computeDataAttributes } from './computeDataAttributes';
 export { default as isChildType } from './isChildType';
 export { default as ssrSafeNotFirstChildSelector } from './ssrSafeNotFirstChildSelector';
 export { default as childrenOfType } from './childrenOfType';
+export { default as hexToRgbaColor } from './hexToRgbaColor';

--- a/packages/react-components/button/package.json
+++ b/packages/react-components/button/package.json
@@ -65,7 +65,6 @@
     "prop-types": "^15.7.2",
     "react-merge-refs": "^1.1.0",
     "react-uid": "^2.3.1",
-    "tinycolor2": "^1.4.2",
     "use-callback-ref": "^1.2.4"
   },
   "peerDependencies": {

--- a/packages/react-components/button/package.json
+++ b/packages/react-components/button/package.json
@@ -62,7 +62,6 @@
     "@datacamp/waffles-tooltip": "^0.2.6",
     "@datacamp/waffles-utils": "^3.1.1",
     "airbnb-prop-types": "^2.16.0",
-    "lodash": "^4.17.20",
     "prop-types": "^15.7.2",
     "react-merge-refs": "^1.1.0",
     "react-uid": "^2.3.1",

--- a/packages/react-components/button/src/Button/buttonStyles.ts
+++ b/packages/react-components/button/src/Button/buttonStyles.ts
@@ -1,6 +1,5 @@
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
 import { css, SerializedStyles } from '@emotion/react';
-import _ from 'lodash';
 import tinycolor from 'tinycolor2';
 
 interface IntentMap {
@@ -30,8 +29,15 @@ const primaryHoverColors: IntentMap = {
   warning: tokens.color.primary.orangeLight.value.hex,
 };
 
-const outlineHoverColors: IntentMap = _.mapValues(baseColors, (value) =>
-  tinycolor(value).setAlpha(0.15).toRgbString(),
+const outlineHoverColors: IntentMap = Object.entries(baseColors).reduce(
+  (hoverColors, baseColor) => {
+    const [intent, value] = baseColor;
+    return {
+      ...hoverColors,
+      [intent]: tinycolor(value).setAlpha(0.15).toRgbString(),
+    };
+  },
+  {} as IntentMap,
 );
 
 // BASE STYLES

--- a/packages/react-components/button/src/Button/buttonStyles.ts
+++ b/packages/react-components/button/src/Button/buttonStyles.ts
@@ -1,6 +1,6 @@
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
+import { hexToRgbaColor } from '@datacamp/waffles-utils';
 import { css, SerializedStyles } from '@emotion/react';
-import tinycolor from 'tinycolor2';
 
 interface IntentMap {
   b2b: string;
@@ -34,7 +34,7 @@ const outlineHoverColors: IntentMap = Object.entries(baseColors).reduce(
     const [intent, value] = baseColor;
     return {
       ...hoverColors,
-      [intent]: tinycolor(value).setAlpha(0.15).toRgbString(),
+      [intent]: hexToRgbaColor(value, 0.15),
     };
   },
   {} as IntentMap,
@@ -135,9 +135,10 @@ const getInvertedStyle = (intent: Intent, enabled: boolean): SerializedStyles =>
         },
         enabled && {
           ':hover': {
-            backgroundColor: tinycolor(tokens.color.primary.white.value.hex)
-              .setAlpha(0.15)
-              .toRgbString(),
+            backgroundColor: hexToRgbaColor(
+              tokens.color.primary.white.value.hex,
+              0.15,
+            ),
           },
         },
       )

--- a/packages/react-components/button/src/SocialMediaButtons/index.tsx
+++ b/packages/react-components/button/src/SocialMediaButtons/index.tsx
@@ -5,8 +5,7 @@ import {
   TwitterBrandIcon,
 } from '@datacamp/waffles-icons';
 import tokens from '@datacamp/waffles-tokens';
-import React from 'react';
-import tinycolor from 'tinycolor2';
+import { hexToRgbaColor } from '@datacamp/waffles-utils';
 
 import Button from '../Button';
 
@@ -25,7 +24,7 @@ const socialMediaButtonFactory = (
     className={className}
     css={{
       ':hover': {
-        backgroundColor: tinycolor(color).setAlpha(0.15).toRgbString(),
+        backgroundColor: hexToRgbaColor(color, 0.15),
         borderColor: color,
         color,
       },

--- a/packages/react-components/card/package.json
+++ b/packages/react-components/card/package.json
@@ -45,7 +45,6 @@
     "@stryker-mutator/typescript": "^4.0.0",
     "@testing-library/jest-dom": "5.11.6",
     "@testing-library/react": "11.2.2",
-    "@types/lodash": "4.14.165",
     "babel-jest": "26.6.3",
     "jest": "26.6.1",
     "react": "17.0.1",
@@ -55,7 +54,6 @@
   "dependencies": {
     "@babel/runtime": "^7.12.1",
     "@datacamp/waffles-tokens": "^1.0.6",
-    "lodash": "^4.17.20",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/react-components/form-elements/package.json
+++ b/packages/react-components/form-elements/package.json
@@ -45,7 +45,6 @@
     "@testing-library/jest-dom": "5.11.6",
     "@testing-library/react": "11.2.2",
     "@testing-library/user-event": "12.7.2",
-    "@types/lodash": "4.14.165",
     "babel-jest": "26.6.3",
     "jest": "26.6.1",
     "react": "17.0.1",
@@ -60,7 +59,7 @@
     "@datacamp/waffles-utils": "^3.1.1",
     "@react-aria/focus": "3.3.0",
     "airbnb-prop-types": "^2.16.0",
-    "lodash": "^4.17.20",
+    "array-union": "^3.0.1",
     "prop-types": "^15.7.2",
     "tinycolor2": "^1.4.2"
   },

--- a/packages/react-components/form-elements/package.json
+++ b/packages/react-components/form-elements/package.json
@@ -59,7 +59,6 @@
     "@datacamp/waffles-utils": "^3.1.1",
     "@react-aria/focus": "3.3.0",
     "airbnb-prop-types": "^2.16.0",
-    "array-union": "^3.0.1",
     "prop-types": "^15.7.2",
     "tinycolor2": "^1.4.2"
   },

--- a/packages/react-components/form-elements/package.json
+++ b/packages/react-components/form-elements/package.json
@@ -59,8 +59,7 @@
     "@datacamp/waffles-utils": "^3.1.1",
     "@react-aria/focus": "3.3.0",
     "airbnb-prop-types": "^2.16.0",
-    "prop-types": "^15.7.2",
-    "tinycolor2": "^1.4.2"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "@emotion/react": "^11.0.0",

--- a/packages/react-components/form-elements/src/CheckboxList/Checkbox.tsx
+++ b/packages/react-components/form-elements/src/CheckboxList/Checkbox.tsx
@@ -2,7 +2,6 @@ import { Text } from '@datacamp/waffles-text';
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
 import { ssrSafeNotFirstChildSelector } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
-import _ from 'lodash';
 import React, { ReactElement } from 'react';
 
 import CheckboxIcon from './CheckboxIcon';
@@ -53,7 +52,7 @@ const Checkbox = ({
 
   const elementDisabled = disabled || contextValue.disabled;
   const handleChange = (): void => contextValue.onChange(value);
-  const isChecked = _.includes(contextValue.value, value);
+  const isChecked = contextValue.value.includes(value);
 
   const focusColor = contextValue.hasError
     ? tokens.color.primary.redDark.value.hex

--- a/packages/react-components/form-elements/src/CheckboxList/index.tsx
+++ b/packages/react-components/form-elements/src/CheckboxList/index.tsx
@@ -1,5 +1,4 @@
 import { childrenOfType } from '@datacamp/waffles-utils';
-import union from 'array-union';
 import PropTypes from 'prop-types';
 import React, { ReactElement } from 'react';
 
@@ -66,7 +65,7 @@ const CheckboxList = ({
       // removes if already exists, adds if it doesn't
       const newValue = value.includes(changedValue)
         ? value.filter((item) => item !== changedValue)
-        : union(value, [changedValue]);
+        : [...new Set(value.concat(changedValue))]; // array union
 
       onChange(newValue);
     },

--- a/packages/react-components/form-elements/src/CheckboxList/index.tsx
+++ b/packages/react-components/form-elements/src/CheckboxList/index.tsx
@@ -1,5 +1,5 @@
 import { childrenOfType } from '@datacamp/waffles-utils';
-import _ from 'lodash';
+import union from 'array-union';
 import PropTypes from 'prop-types';
 import React, { ReactElement } from 'react';
 
@@ -64,9 +64,9 @@ const CheckboxList = ({
   const handleChange = React.useCallback(
     (changedValue: string): void => {
       // removes if already exists, adds if it doesn't
-      const newValue = _.includes(value, changedValue)
-        ? _.filter(value, (item) => item !== changedValue)
-        : _.union(value, [changedValue]);
+      const newValue = value.includes(changedValue)
+        ? value.filter((item) => item !== changedValue)
+        : union(value, [changedValue]);
 
       onChange(newValue);
     },

--- a/packages/react-components/form-elements/src/Switch/Input.tsx
+++ b/packages/react-components/form-elements/src/Switch/Input.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 
 // Checkbox is visually hidden but remains accessible to screen readers
 const inputStyle = css({
@@ -15,8 +15,11 @@ const inputStyle = css({
   zIndex: -1,
 });
 
-function Input(props: InputHTMLAttributes<HTMLInputElement>): JSX.Element {
-  return <input css={inputStyle} {...props} />;
-}
+const Input = forwardRef<
+  HTMLInputElement,
+  InputHTMLAttributes<HTMLInputElement>
+>((props, ref) => {
+  return <input css={inputStyle} ref={ref} {...props} />;
+});
 
 export default Input;

--- a/packages/react-components/form-elements/src/Switch/index.tsx
+++ b/packages/react-components/form-elements/src/Switch/index.tsx
@@ -1,5 +1,10 @@
 import { useFocusRing } from '@react-aria/focus';
-import { FormEventHandler, InputHTMLAttributes, ReactNode } from 'react';
+import {
+  FormEventHandler,
+  forwardRef,
+  InputHTMLAttributes,
+  ReactNode,
+} from 'react';
 
 import Input from './Input';
 import Label from './Label';
@@ -37,32 +42,38 @@ export type SwitchProps = {
 ) &
   InputHTMLAttributes<HTMLInputElement>;
 
-function Switch({
-  appearance = 'default',
-  checked,
-  children,
-  className,
-  disabled,
-  ...restProps
-}: SwitchProps): JSX.Element {
-  const { focusProps, isFocusVisible } = useFocusRing();
+const Switch = forwardRef<HTMLInputElement, SwitchProps>(
+  (
+    {
+      appearance = 'default',
+      checked,
+      children,
+      className,
+      disabled,
+      ...restProps
+    },
+    ref,
+  ) => {
+    const { focusProps, isFocusVisible } = useFocusRing();
 
-  return (
-    <Label {...{ appearance, children, className, disabled }}>
-      <Input
-        aria-checked={checked}
-        disabled={disabled}
-        role="switch"
-        type="checkbox"
-        {...restProps}
-        {...focusProps}
-      />
-      <Toggle
-        {...{ appearance, checked, hasLabel: !!children, isFocusVisible }}
-      />
-      {children}
-    </Label>
-  );
-}
+    return (
+      <Label {...{ appearance, children, className, disabled }}>
+        <Input
+          aria-checked={checked}
+          disabled={disabled}
+          ref={ref}
+          role="switch"
+          type="checkbox"
+          {...restProps}
+          {...focusProps}
+        />
+        <Toggle
+          {...{ appearance, checked, hasLabel: !!children, isFocusVisible }}
+        />
+        {children}
+      </Label>
+    );
+  },
+);
 
 export default Switch;

--- a/packages/react-components/form-elements/src/formStyles.ts
+++ b/packages/react-components/form-elements/src/formStyles.ts
@@ -1,10 +1,11 @@
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
+import { hexToRgbaColor } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
-import tinycolor from 'tinycolor2';
 
-const placeholderColor = tinycolor(tokens.color.primary.navyText.value.rgb)
-  .setAlpha(0.6)
-  .toRgbString();
+const placeholderColor = hexToRgbaColor(
+  tokens.color.primary.navyText.value.rgb,
+  0.6,
+);
 
 const baseFormStyle = css({
   ':disabled, :active:disabled, :focus:disabled': {

--- a/packages/react-components/form-elements/src/formStyles.ts
+++ b/packages/react-components/form-elements/src/formStyles.ts
@@ -3,7 +3,7 @@ import { hexToRgbaColor } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
 
 const placeholderColor = hexToRgbaColor(
-  tokens.color.primary.navyText.value.rgb,
+  tokens.color.primary.navyText.value.hex,
   0.6,
 );
 

--- a/packages/react-components/modals/package.json
+++ b/packages/react-components/modals/package.json
@@ -45,7 +45,6 @@
     "@testing-library/jest-dom": "5.11.6",
     "@testing-library/react": "11.2.2",
     "@testing-library/user-event": "12.7.2",
-    "@types/lodash": "4.14.165",
     "@types/tinycolor2": "1.4.2",
     "babel-jest": "26.6.3",
     "jest": "26.6.1",
@@ -63,7 +62,6 @@
     "@datacamp/waffles-utils": "^3.1.1",
     "@types/react-modal": "^3.10.6",
     "airbnb-prop-types": "^2.16.0",
-    "lodash": "^4.17.20",
     "prop-types": "^15.7.2",
     "react-modal": "^3.12.1",
     "tinycolor2": "^1.4.2"

--- a/packages/react-components/modals/package.json
+++ b/packages/react-components/modals/package.json
@@ -45,7 +45,6 @@
     "@testing-library/jest-dom": "5.11.6",
     "@testing-library/react": "11.2.2",
     "@testing-library/user-event": "12.7.2",
-    "@types/tinycolor2": "1.4.2",
     "babel-jest": "26.6.3",
     "jest": "26.6.1",
     "react": "17.0.1",
@@ -63,8 +62,7 @@
     "@types/react-modal": "^3.10.6",
     "airbnb-prop-types": "^2.16.0",
     "prop-types": "^15.7.2",
-    "react-modal": "^3.12.1",
-    "tinycolor2": "^1.4.2"
+    "react-modal": "^3.12.1"
   },
   "peerDependencies": {
     "@emotion/react": "^11.0.0",

--- a/packages/react-components/modals/src/Dialog/StepsIndicator.tsx
+++ b/packages/react-components/modals/src/Dialog/StepsIndicator.tsx
@@ -1,6 +1,5 @@
 import { ssrSafeNotFirstChildSelector } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
-import _ from 'lodash';
 import React from 'react';
 
 const indicatorStyle = css({
@@ -26,15 +25,17 @@ const StepsIndicator: React.FC<StepsIndicatorProps> = ({
     aria-label={`Step ${currentStep} of ${totalSteps}`}
     css={{ lineHeight: '8px', marginTop: 16, padding: 0 }}
   >
-    {_.times(totalSteps, (i) => (
-      <div
-        css={css(indicatorStyle, {
-          backgroundColor:
-            i >= currentStep ? 'rgba(255, 255, 255, 0.3)' : 'white',
-        })}
-        key={i}
-      />
-    ))}
+    {[...Array(totalSteps).keys()].map((step) => {
+      return (
+        <div
+          css={css(indicatorStyle, {
+            backgroundColor:
+              step >= currentStep ? 'rgba(255, 255, 255, 0.3)' : 'white',
+          })}
+          key={step}
+        />
+      );
+    })}
   </div>
 );
 

--- a/packages/react-components/modals/src/sharedStyles.ts
+++ b/packages/react-components/modals/src/sharedStyles.ts
@@ -1,14 +1,12 @@
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
+import { hexToRgbaColor } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
-import tinycolor from 'tinycolor2';
 
 export const bodyOpenStyle = css({ overflow: 'hidden' });
 
 export const overlayStyle = css({
   alignItems: 'center',
-  backgroundColor: tinycolor(tokens.color.primary.navy.value.rgb)
-    .setAlpha(0.8)
-    .toRgbString(),
+  backgroundColor: hexToRgbaColor(tokens.color.primary.navy.value.rgb, 0.8),
   bottom: 0,
   display: 'flex',
   justifyContent: 'center',

--- a/packages/react-components/modals/src/sharedStyles.ts
+++ b/packages/react-components/modals/src/sharedStyles.ts
@@ -6,7 +6,7 @@ export const bodyOpenStyle = css({ overflow: 'hidden' });
 
 export const overlayStyle = css({
   alignItems: 'center',
-  backgroundColor: hexToRgbaColor(tokens.color.primary.navy.value.rgb, 0.8),
+  backgroundColor: hexToRgbaColor(tokens.color.primary.navy.value.hex, 0.8),
   bottom: 0,
   display: 'flex',
   justifyContent: 'center',

--- a/packages/react-components/resizable-elements/package.json
+++ b/packages/react-components/resizable-elements/package.json
@@ -50,7 +50,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.1",
-    "lodash": "^4.17.20",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/react-components/resizable-elements/src/ResizableElements.tsx
+++ b/packages/react-components/resizable-elements/src/ResizableElements.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import _ from 'lodash';
 import React, { useCallback } from 'react';
 
 import calculateSizes from './calculateSizes';
@@ -66,7 +65,7 @@ const ResizableElements = ({
     collapsedSize,
     sizePercentages:
       initialProportions ||
-      (_.times(nbChildren, () => 100 / nbChildren) as number[]),
+      [...Array(nbChildren).keys()].map(() => 100 / nbChildren),
   });
 
   const containerRef = React.useRef<HTMLDivElement>(null);

--- a/packages/react-components/text/package.json
+++ b/packages/react-components/text/package.json
@@ -40,6 +40,7 @@
     "@stryker-mutator/typescript": "^4.0.0",
     "@testing-library/jest-dom": "5.11.6",
     "@testing-library/react": "11.2.2",
+    "@types/tinycolor2": "^1.4.2",
     "babel-jest": "26.6.3",
     "jest": "26.6.1",
     "react": "17.0.1",

--- a/packages/react-components/text/package.json
+++ b/packages/react-components/text/package.json
@@ -40,7 +40,6 @@
     "@stryker-mutator/typescript": "^4.0.0",
     "@testing-library/jest-dom": "5.11.6",
     "@testing-library/react": "11.2.2",
-    "@types/lodash": "4.14.165",
     "babel-jest": "26.6.3",
     "jest": "26.6.1",
     "react": "17.0.1",
@@ -52,7 +51,6 @@
     "@datacamp/waffles-tokens": "^1.0.6",
     "@datacamp/waffles-utils": "^3.1.1",
     "airbnb-prop-types": "^2.16.0",
-    "lodash": "^4.17.20",
     "prop-types": "^15.7.2",
     "react-uid": "^2.3.1",
     "tinycolor2": "^1.4.2"

--- a/packages/stylesheets/core/package.json
+++ b/packages/stylesheets/core/package.json
@@ -37,7 +37,7 @@
     "mini-css-extract-plugin": "1.3.6",
     "node-sass": "4.14.1",
     "node-sass-json-importer": "4.3.0",
-    "omit-deep-lodash": "1.1.5",
+    "omit-deep": "^0.3.0",
     "optimize-css-assets-webpack-plugin": "^5.0.4",
     "postcss-browser-reporter": "^0.6.0",
     "postcss-import": "^12.0.1",
@@ -55,7 +55,6 @@
   "gitHead": "033030174dbf18623ccd9c0174108c41a9e588a1",
   "dependencies": {
     "@datacamp/waffles-tokens": "^1.0.6",
-    "file-loader": "1.1.11",
-    "lodash": "^4.17.20"
+    "file-loader": "1.1.11"
   }
 }

--- a/packages/stylesheets/core/test/core.spec.js
+++ b/packages/stylesheets/core/test/core.spec.js
@@ -1,7 +1,6 @@
 const dirTree = require('directory-tree');
 const fs = require('fs');
-const omitDeep = require('omit-deep-lodash');
-const _ = require('lodash');
+const omitDeep = require('omit-deep');
 
 // remove hash from filename so snapshots are diffed rather than recreated
 const replaceFileName = (fileName) =>
@@ -11,8 +10,7 @@ describe('Core', () => {
   it('has correct file structure', () => {
     const dir = dirTree('lib');
     const structure = omitDeep(dir, 'size');
-    const cssDirIndex = _.findIndex(
-      structure.children,
+    const cssDirIndex = structure.children.findIndex(
       ({ name }) => name === 'css',
     );
     const cssFiles = structure.children[cssDirIndex].children;

--- a/packages/tools/babel-preset/index.js
+++ b/packages/tools/babel-preset/index.js
@@ -2,7 +2,6 @@ const presetEnv = require('@babel/preset-env').default;
 const presetReact = require('@babel/preset-react').default;
 const presetTypescript = require('@babel/preset-typescript').default;
 const presetCSSProp = require('@emotion/babel-preset-css-prop').default;
-const pluginLodash = require('babel-plugin-lodash');
 const pluginTypescriptToProptypes = require('babel-plugin-typescript-to-proptypes')
   .default;
 const pluginTransformRuntime = require('@babel/plugin-transform-runtime');
@@ -43,7 +42,6 @@ module.exports = () => ({
     test: { presets: [presetCSSProp] },
   },
   plugins: [
-    pluginLodash,
     pluginProposalClassProperties,
     pluginTypescriptToProptypes,
     [pluginTransformReactRemovePropTypes, { mode: 'wrap' }], // must happen after typescript to proptypes conversion

--- a/packages/tools/babel-preset/package.json
+++ b/packages/tools/babel-preset/package.json
@@ -12,7 +12,6 @@
     "@babel/preset-react": "^7.12.13",
     "@babel/preset-typescript": "^7.12.1",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "babel-plugin-typescript-to-proptypes": "^1.4.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6260,6 +6260,11 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+array-union@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-3.0.1.tgz#da52630d327f8b88cfbfb57728e2af5cd9b6b975"
+  integrity sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==
+
 array-uniq@^1.0.1, array-uniq@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
@@ -10375,7 +10380,7 @@ dedent@0.7.0, dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
-deep-cleaner@1.2.1:
+deep-cleaner@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/deep-cleaner/-/deep-cleaner-1.2.1.tgz#abc30c05bbf79a43abaf449da50e41d89ba47890"
   integrity sha512-/WLL2O+GnNA/t9DRagOBT7ckJnfz5wV/8TqLo5bHykcBlXPH0+PeUzd0/s2MzOQ3IiRRIFpcWVe016rCqQIhMA==
@@ -15507,10 +15512,17 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.0, json5@^2.1.1, json5@^2.1.2, json5@^2.1.3:
+json5@^2.1.0, json5@^2.1.1, json5@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  dependencies:
+    minimist "^1.2.5"
+
+json5@^2.1.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
 
@@ -17990,12 +18002,20 @@ octokit-pagination-methods@^1.1.0:
   resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
   integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
 
-omit-deep-lodash@1.1.5, omit-deep-lodash@^1.1.5:
+omit-deep-lodash@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/omit-deep-lodash/-/omit-deep-lodash-1.1.5.tgz#12dfc0dbd5a00e73d8a28175e2b5f40fedeffb2b"
   integrity sha512-WtPD4SLmyas/ETFeU5j8chvh0LY5dN2q3s056aMZyV+thDMx+pFJ1DLenm7fShnHpmEMQ97Nez7j+FLtGSdgKQ==
   dependencies:
     lodash "~4.17.20"
+
+omit-deep@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/omit-deep/-/omit-deep-0.3.0.tgz#21c8af3499bcadd29651a232cbcacbc52445ebec"
+  integrity sha1-IcivNJm8rdKWUaIyy8rLxSRF6+w=
+  dependencies:
+    is-plain-object "^2.0.1"
+    unset-value "^0.1.1"
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -23040,10 +23060,10 @@ strong-log-transformer@^2.0.0:
     minimist "^1.2.0"
     through "^2.3.4"
 
-style-dictionary@2.10.2:
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/style-dictionary/-/style-dictionary-2.10.2.tgz#9150dfcdc1492e1cd5f0f0a73e2bc6ada349c09b"
-  integrity sha512-1GgtokijUl46tFXFGMmGPioO9xMzTBcCRfufYUZ61OxYRUEDT93M7Y9YxD+udgrHN2pYRrS/CiToM4jARBTccQ==
+style-dictionary@^2.10.3:
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/style-dictionary/-/style-dictionary-2.10.3.tgz#7c89f8020524172df6e534ab4217f6923e1daf7b"
+  integrity sha512-iSDb8T2tMSB5JcTQ7uquB+W3oO7kuJbb+QrSQMiQjBCOa7AGYtWzYo/O7rl3f9Hj956w41WVw9HpTpYfFWwU+g==
   dependencies:
     chalk "^4.0.0"
     commander "^5.1.0"
@@ -24395,6 +24415,14 @@ unquote@^1.1.0, unquote@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
   integrity sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=
+
+unset-value@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-0.1.2.tgz#506810b867f27c2a5a6e9b04833631f6de58d310"
+  integrity sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=
+  dependencies:
+    has-value "^0.3.1"
+    isobject "^3.0.0"
 
 unset-value@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5213,7 +5213,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/tinycolor2@1.4.2":
+"@types/tinycolor2@^1.4.2":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@types/tinycolor2/-/tinycolor2-1.4.2.tgz#721ca5c5d1a2988b4a886e35c2ffc5735b6afbdf"
   integrity sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6260,11 +6260,6 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
-array-union@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-3.0.1.tgz#da52630d327f8b88cfbfb57728e2af5cd9b6b975"
-  integrity sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==
-
 array-uniq@^1.0.1, array-uniq@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"


### PR DESCRIPTION
## Proposed changes

Removed **lodash** wherever it made sense or where it was not used at all. Whole bundle size went down by **~600KB** uncompressed.
Replaced **tinycolor2** with custom function. **tinycolor2** is only left in **Text** package.
Passed **ref** to Switch component.

TODO:
Replace tinycolor2 in Text.

Before:
![lodash-before](https://user-images.githubusercontent.com/20565536/119856528-13a81b00-bf13-11eb-9737-6094c099d87c.png)

After:
![lodash-after](https://user-images.githubusercontent.com/20565536/119856553-199dfc00-bf13-11eb-9711-8a49e4292994.png)

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [ ] ~~Technical docs written~~
- [ ] ~~Structural changes reflected in Readme~~
- [ ] ~~Migration plan for breaking changes~~

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] ~~Approved by Designer, Engineer, & PO~~
