### PR TITLE
Remove tinyclor2

### DIFF
--- a/packages/docs/storybook/stories/text.stories.js
+++ b/packages/docs/storybook/stories/text.stories.js
@@ -414,7 +414,19 @@ gapminder %>%
         <Badge color="#ffc844" size="large">
           Badge
         </Badge>
-        <Badge color="rgb(207, 220, 225)" size="large">
+        <Badge color={color.primary.green.value.hex} size="large">
+          Badge
+        </Badge>
+        <Badge color={color.primary.purple.value.hex} size="large">
+          Badge
+        </Badge>
+        <Badge color={color.primary.yellowLight.value.hex} size="large">
+          Badge
+        </Badge>
+        <Badge color={color.primary.navyDark.value.hex} size="large">
+          Badge
+        </Badge>
+        <Badge color={color.neutral.beige400.value.hex} size="large">
           Badge
         </Badge>
       </div>
@@ -427,7 +439,11 @@ gapminder %>%
       >
         <Badge color="#3ac">Badge</Badge>
         <Badge color="#ffc844">Badge</Badge>
-        <Badge color="rgb(207, 220, 225)">Badge</Badge>
+        <Badge color={color.primary.green.value.hex}>Badge</Badge>
+        <Badge color={color.primary.purple.value.hex}>Badge</Badge>
+        <Badge color={color.primary.yellowLight.value.hex}>Badge</Badge>
+        <Badge color={color.primary.navyDark.value.hex}>Badge</Badge>
+        <Badge color={color.neutral.beige400.value.hex}>Badge</Badge>
       </div>
     </div>
   ))

--- a/packages/other/utils/src/hexColorLuminance.spec.ts
+++ b/packages/other/utils/src/hexColorLuminance.spec.ts
@@ -1,0 +1,26 @@
+import hexColorLuminance from './hexColorLuminance';
+
+describe('hexColorLuminance', () => {
+  it('converts HEX color value to RGB counterpart when opacity is not provided', () => {
+    expect(hexColorLuminance('#0033FF')).toEqual(0.096);
+    expect(hexColorLuminance('#03f')).toEqual(0.096);
+    expect(hexColorLuminance('#03ef62')).toEqual(0.626);
+    expect(hexColorLuminance('#777')).toEqual(0.184);
+    expect(hexColorLuminance('#FFF')).toEqual(1);
+    expect(hexColorLuminance('#000000')).toEqual(0);
+  });
+
+  it('throws an error when icorrect HEX value is provided', () => {
+    const ERROR_MESSAGE =
+      "Couldn't parse the color string. Please provide the color as a string in HEX notation.";
+    expect(() => {
+      hexColorLuminance('abc');
+    }).toThrow(ERROR_MESSAGE);
+    expect(() => {
+      hexColorLuminance('#ABC1');
+    }).toThrow(ERROR_MESSAGE);
+    expect(() => {
+      hexColorLuminance('#AB');
+    }).toThrow(ERROR_MESSAGE);
+  });
+});

--- a/packages/other/utils/src/hexColorLuminance.ts
+++ b/packages/other/utils/src/hexColorLuminance.ts
@@ -1,0 +1,30 @@
+import hexToRgbaColor from './hexToRgbaColor';
+
+const rgbaRegex = /^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/i;
+
+/**
+ * Calculates HEX color luminance
+ */
+function hexColorLuminance(hexColor: string): number {
+  const rgbaColor = hexToRgbaColor(hexColor);
+  const rgbaMatched = rgbaRegex.exec(rgbaColor);
+
+  if (!rgbaMatched) {
+    throw new Error("Couldn't parse the RGBA color string.");
+  }
+
+  // Grab red, green, blue channels, since we don't need alpha
+  const channels = [1, 2, 3].map((index) => {
+    return parseInt(`${rgbaMatched[index]}`, 10);
+  });
+
+  const [r, g, b] = channels.map((value) => {
+    const channel = value / 255;
+    return channel <= 0.03928
+      ? channel / 12.92
+      : ((channel + 0.055) / 1.055) ** 2.4;
+  });
+  return parseFloat((0.2126 * r + 0.7152 * g + 0.0722 * b).toFixed(3));
+}
+
+export default hexColorLuminance;

--- a/packages/other/utils/src/hexToRgbaColor.spec.ts
+++ b/packages/other/utils/src/hexToRgbaColor.spec.ts
@@ -3,7 +3,7 @@ import hexToRgbaColor from './hexToRgbaColor';
 
 describe('hexToRgbaColor', () => {
   it('converts HEX color value to RGB counterpart when opacity is not provided', () => {
-    expect(hexToRgbaColor('#0033ff')).toEqual('rgba(0, 51, 255, 1)');
+    expect(hexToRgbaColor('#0033FF')).toEqual('rgba(0, 51, 255, 1)');
     expect(hexToRgbaColor('#03f')).toEqual('rgba(0, 51, 255, 1)');
     expect(hexToRgbaColor('#03ef62')).toEqual('rgba(3, 239, 98, 1)');
   });
@@ -14,7 +14,30 @@ describe('hexToRgbaColor', () => {
     expect(hexToRgbaColor('#03f', 1)).toEqual('rgba(0, 51, 255, 1)');
     expect(hexToRgbaColor('#03f', 0)).toEqual('rgba(0, 51, 255, 0)');
     expect(hexToRgbaColor('#03ef62', 0.3)).toEqual('rgba(3, 239, 98, 0.3)');
-    expect(hexToRgbaColor('#03ef62', 1)).toEqual('rgba(3, 239, 98, 1)');
+    expect(hexToRgbaColor('#03EF62', 1)).toEqual('rgba(3, 239, 98, 1)');
     expect(hexToRgbaColor('#03ef62', 0)).toEqual('rgba(3, 239, 98, 0)');
+  });
+
+  it('throws an error when icorrect HEX value is provided', () => {
+    const ERROR_MESSAGE =
+      "Couldn't parse the color string. Please provide the color as a string in HEX notation.";
+    expect(() => {
+      hexToRgbaColor('abc');
+    }).toThrow(ERROR_MESSAGE);
+    expect(() => {
+      hexToRgbaColor('');
+    }).toThrow(ERROR_MESSAGE);
+    expect(() => {
+      hexToRgbaColor('#');
+    }).toThrow(ERROR_MESSAGE);
+    expect(() => {
+      hexToRgbaColor('#ABC1');
+    }).toThrow(ERROR_MESSAGE);
+    expect(() => {
+      hexToRgbaColor('#AB');
+    }).toThrow(ERROR_MESSAGE);
+    expect(() => {
+      hexToRgbaColor('#abb34a7');
+    }).toThrow(ERROR_MESSAGE);
   });
 });

--- a/packages/other/utils/src/hexToRgbaColor.ts
+++ b/packages/other/utils/src/hexToRgbaColor.ts
@@ -1,8 +1,16 @@
+const hexRegex = /^#([a-fA-F0-9]{3}){1,2}$/;
+
 /**
  * Converts HEX color to RGBA counterpart, with optional alpha setting
  */
-const hexToRgbaColor = (hex: string, alpha = 1): string => {
-  const value = hex.slice(1);
+const hexToRgbaColor = (hexColor: string, alpha = 1): string => {
+  if (!hexRegex.test(hexColor)) {
+    throw new Error(
+      "Couldn't parse the color string. Please provide the color as a string in HEX notation.",
+    );
+  }
+
+  const value = hexColor.slice(1);
   const group = value.length / 3;
   return `rgba(${[0, 1, 2]
     .map((i) => value.slice(i * group, (i + 1) * group))

--- a/packages/other/utils/src/index.spec.ts
+++ b/packages/other/utils/src/index.spec.ts
@@ -1,5 +1,6 @@
 import childrenOfType from './childrenOfType';
 import computeDataAttributes from './computeDataAttributes';
+import hexColorLuminance from './hexColorLuminance';
 import hexToRgbaColor from './hexToRgbaColor';
 import isChildType from './isChildType';
 import ssrSafeNotFirstChildSelector from './ssrSafeNotFirstChildSelector';
@@ -11,6 +12,7 @@ describe('waffles-utils', () => {
     expect(utils).toEqual({
       childrenOfType,
       computeDataAttributes,
+      hexColorLuminance,
       hexToRgbaColor,
       isChildType,
       ssrSafeNotFirstChildSelector,

--- a/packages/other/utils/src/index.ts
+++ b/packages/other/utils/src/index.ts
@@ -3,3 +3,4 @@ export { default as isChildType } from './isChildType';
 export { default as ssrSafeNotFirstChildSelector } from './ssrSafeNotFirstChildSelector';
 export { default as childrenOfType } from './childrenOfType';
 export { default as hexToRgbaColor } from './hexToRgbaColor';
+export { default as hexColorLuminance } from './hexColorLuminance';

--- a/packages/react-components/text/package.json
+++ b/packages/react-components/text/package.json
@@ -40,7 +40,6 @@
     "@stryker-mutator/typescript": "^4.0.0",
     "@testing-library/jest-dom": "5.11.6",
     "@testing-library/react": "11.2.2",
-    "@types/tinycolor2": "^1.4.2",
     "babel-jest": "26.6.3",
     "jest": "26.6.1",
     "react": "17.0.1",
@@ -53,8 +52,7 @@
     "@datacamp/waffles-utils": "^3.2.0",
     "airbnb-prop-types": "^2.16.0",
     "prop-types": "^15.7.2",
-    "react-uid": "^2.3.1",
-    "tinycolor2": "^1.4.2"
+    "react-uid": "^2.3.1"
   },
   "peerDependencies": {
     "@emotion/react": "^11.0.0",

--- a/packages/react-components/text/src/components/Badge.spec.tsx
+++ b/packages/react-components/text/src/components/Badge.spec.tsx
@@ -2,7 +2,6 @@ import '@testing-library/jest-dom/extend-expect';
 
 import axeRender from '@datacamp/waffles-axe-render';
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
-import React from 'react';
 
 import Badge from './Badge';
 
@@ -10,12 +9,14 @@ describe('Badge', () => {
   const testContent = 'test content';
   it('renders with the provided colour, className and content', async () => {
     const { getByText } = await axeRender(
-      <Badge className="test-class" color="black">
+      <Badge className="test-class" color={tokens.color.primary.navy.value.hex}>
         {testContent}
       </Badge>,
     );
     const element = getByText(testContent) as HTMLElement;
-    expect(element).toHaveStyle('background-color: black');
+    expect(element).toHaveStyle(
+      `background-color: ${tokens.color.primary.navy.value.hex}`,
+    );
     expect(element).toHaveClass('test-class');
     expect(element).toMatchSnapshot();
   });
@@ -23,7 +24,7 @@ describe('Badge', () => {
   describe('size', () => {
     it('renders a small badge', async () => {
       const { getByText } = await axeRender(
-        <Badge color="black" size="small">
+        <Badge color={tokens.color.primary.navy.value.hex} size="small">
           {testContent}
         </Badge>,
       );
@@ -40,7 +41,7 @@ describe('Badge', () => {
 
     it('renders a large badge', async () => {
       const { getByText } = await axeRender(
-        <Badge color="black" size="large">
+        <Badge color={tokens.color.primary.navy.value.hex} size="large">
           {testContent}
         </Badge>,
       );

--- a/packages/react-components/text/src/components/Badge.tsx
+++ b/packages/react-components/text/src/components/Badge.tsx
@@ -1,7 +1,7 @@
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
+import { hexColorLuminance } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
 import React from 'react';
-import tinycolor from 'tinycolor2';
 
 import Strong from './Strong';
 
@@ -15,9 +15,9 @@ interface BadgeProps {
    */
   className?: string;
   /**
-   * The colour of the Badge. This can be any css colour, but it is recommended
-   * to use a colour from @datacamp/waffles-tokens. The text color will be set
-   * automatically based on this colour.
+   * The colour of the Badge. This can be any HEX color, but it is recommended
+   * to use a color from @datacamp/waffles-tokens. The text color will be set
+   * automatically.
    */
   color: string;
   /**
@@ -48,15 +48,12 @@ const sizeStyles = {
 };
 
 const getTextColor = (backgroundColor: string): string => {
-  if (
-    tinycolor.readability(
-      backgroundColor,
-      tokens.color.primary.navyText.value.hex,
-    ) > 4.5
-  ) {
-    return tokens.color.primary.navyText.value.hex;
-  }
-  return tokens.color.primary.white.value.hex;
+  // Compare to luminance of neutral grey color in the middle of the RGB scale
+  const isColorLight = hexColorLuminance(backgroundColor) > 0.179;
+
+  return isColorLight
+    ? tokens.color.primary.navyText.value.hex
+    : tokens.color.primary.white.value.hex;
 };
 
 const Badge = ({

--- a/packages/react-components/text/src/components/__snapshots__/Badge.spec.tsx.snap
+++ b/packages/react-components/text/src/components/__snapshots__/Badge.spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`Badge renders with the provided colour, className and content 1`] = `
   border-radius: 4px;
   display: inline-block;
   text-transform: uppercase;
-  background-color: black;
+  background-color: #05192d;
   color: #ffffff;
   font-size: 14px;
   line-height: 18px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5213,11 +5213,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/tinycolor2@^1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@types/tinycolor2/-/tinycolor2-1.4.2.tgz#721ca5c5d1a2988b4a886e35c2ffc5735b6afbdf"
-  integrity sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw==
-
 "@types/uglify-js@*":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.0.4.tgz#96beae23df6f561862a830b4288a49e86baac082"


### PR DESCRIPTION
## Proposed changes

Affected component: **Badge** from **Text**

Removed **tinyclor2** dependency, which saves around **35KB** uncompressed from **Text**.
Replaced tinycolor color calculations utils with custom ones.
The caveat is that now Badge could accept only HEX color values as background, but we should use tokens from our lib anyway.

Badge:
<img width="613" alt="badge" src="https://user-images.githubusercontent.com/20565536/120192549-9aaf0900-c21b-11eb-9693-9a228a93c8ab.png">

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [ ] ~~Migration plan for breaking changes~~

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] ~~Approved by Designer, Engineer, & PO~~
