### PR TITLE
fix: deploy only from master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,8 @@ workflows:
           context: org-global
           filters:
             branches:
-              ignore: /.*/
+              only:
+                - master
             tags:
               ignore: /.*beta.*/
       # - deploy-beta-site:


### PR DESCRIPTION
Docs are now deployed when hitting master.