### PR TITLE
Fix Switch props docs

### DIFF
--- a/packages/docs/next-doc-site/pages/components/form-elements.mdx
+++ b/packages/docs/next-doc-site/pages/components/form-elements.mdx
@@ -98,7 +98,7 @@ Waffles exposes several form elements:
 
 <PropsTable component="InternalTextArea" alias="TextArea" metadata={metadata} />
 
-<PropsTable component="Switch" metadata={metadata} />
+<PropsTable component="InternalSwitch" alias="Switch" metadata={metadata} />
 
 Besides that `Switch` accepts all props regular HTML checkbox would accept, such as `name`, `value`, `id`, `data-testid`, to name a few.
 

--- a/packages/react-components/form-elements/src/Switch/index.tsx
+++ b/packages/react-components/form-elements/src/Switch/index.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   InputHTMLAttributes,
   ReactNode,
+  Ref,
 } from 'react';
 
 import Input from './Input';
@@ -42,38 +43,38 @@ export type SwitchProps = {
 ) &
   InputHTMLAttributes<HTMLInputElement>;
 
-const Switch = forwardRef<HTMLInputElement, SwitchProps>(
-  (
-    {
-      appearance = 'default',
-      checked,
-      children,
-      className,
-      disabled,
-      ...restProps
-    },
-    ref,
-  ) => {
-    const { focusProps, isFocusVisible } = useFocusRing();
+function InternalSwitch({
+  appearance = 'default',
+  checked,
+  children,
+  className,
+  disabled,
+  innerRef,
+  ...restProps
+}: SwitchProps & { innerRef?: Ref<HTMLInputElement> }): JSX.Element {
+  const { focusProps, isFocusVisible } = useFocusRing();
 
-    return (
-      <Label {...{ appearance, children, className, disabled }}>
-        <Input
-          aria-checked={checked}
-          disabled={disabled}
-          ref={ref}
-          role="switch"
-          type="checkbox"
-          {...restProps}
-          {...focusProps}
-        />
-        <Toggle
-          {...{ appearance, checked, hasLabel: !!children, isFocusVisible }}
-        />
-        {children}
-      </Label>
-    );
-  },
-);
+  return (
+    <Label {...{ appearance, children, className, disabled }}>
+      <Input
+        aria-checked={checked}
+        disabled={disabled}
+        ref={innerRef}
+        role="switch"
+        type="checkbox"
+        {...restProps}
+        {...focusProps}
+      />
+      <Toggle
+        {...{ appearance, checked, hasLabel: !!children, isFocusVisible }}
+      />
+      {children}
+    </Label>
+  );
+}
+
+const Switch = forwardRef<HTMLInputElement, SwitchProps>((props, ref) => {
+  return <InternalSwitch {...props} innerRef={ref} />;
+});
 
 export default Switch;


### PR DESCRIPTION
Fixed auto generated props table for **Switch** component by extracting it from forwardRef. 