### PR TITLE
Menu item notification

### DIFF
--- a/packages/docs/next-doc-site/examples/button/complete-user-account-menu.tsx
+++ b/packages/docs/next-doc-site/examples/button/complete-user-account-menu.tsx
@@ -38,6 +38,7 @@ function Example(): JSX.Element {
         <UserAccountMenu.MenuItem
           icon={InfoCircleIcon}
           onClick={() => alert("It's so exciting!")}
+          showAlertDot
         >
           Additional Info
         </UserAccountMenu.MenuItem>

--- a/packages/docs/next-doc-site/pages/components/button.mdx
+++ b/packages/docs/next-doc-site/pages/components/button.mdx
@@ -95,7 +95,7 @@ Button type can be used to alter how interactions are handled. `ButtonGroup` and
 
 ### UserAccountMenu.MenuItem
 
-Recommended component to use as a `UserAccountMenu`'s child. Besides the required `icon` from `@datacamp/waffles-icons` it accepts all the same props the regular HTML _anchor_ element would take.
+Recommended component to use as a `UserAccountMenu`'s child. Besides an optional `showAlertDot` and the required `icon` from `@datacamp/waffles-icons` it accepts all the same props the regular HTML _anchor_ element would take.
 
 </Section>
 

--- a/packages/react-components/button/src/Button/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/button/src/Button/__snapshots__/index.spec.tsx.snap
@@ -16254,11 +16254,11 @@ exports[`<Button /> tooltips tooltip appearance snapshots renders a tooltip with
 }
 
 .emotion-2 {
-  background-color: rgb(255, 255, 255);
+  background-color: #ffffff;
   border-radius: 4px;
-  box-shadow: 0 0 0 1px rgba(5,25,45,0.1);
-  -webkit-transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
-  transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25);
   position: fixed;
   left: 0;
   top: 8px;
@@ -16387,11 +16387,11 @@ exports[`<Button /> tooltips tooltip appearance snapshots renders a tooltip with
 }
 
 .emotion-2 {
-  background-color: rgb(255, 255, 255);
+  background-color: #ffffff;
   border-radius: 4px;
-  box-shadow: 0px 0px 1px 0px rgba(5, 25, 45, 0.3),0 2px 4px -1px rgba(5,25,45,0.3);
-  -webkit-transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
-  transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25),0 2px 4px -1px rgba(5,25,45,0.3);
   position: fixed;
   left: 0;
   top: 8px;
@@ -16519,11 +16519,11 @@ exports[`<Button /> tooltips tooltip appearance snapshots renders a tooltip with
 }
 
 .emotion-2 {
-  background-color: rgb(255, 255, 255);
+  background-color: #ffffff;
   border-radius: 4px;
-  box-shadow: 0 0 0 1px rgba(5,25,45,0.1);
-  -webkit-transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
-  transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25);
   position: fixed;
   left: 0;
   top: 8px;
@@ -16652,11 +16652,11 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at b
 }
 
 .emotion-2 {
-  background-color: rgb(255, 255, 255);
+  background-color: #ffffff;
   border-radius: 4px;
-  box-shadow: 0 0 0 1px rgba(5,25,45,0.1);
-  -webkit-transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
-  transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25);
   position: fixed;
   left: 0;
   top: 8px;
@@ -16785,11 +16785,11 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at b
 }
 
 .emotion-2 {
-  background-color: rgb(255, 255, 255);
+  background-color: #ffffff;
   border-radius: 4px;
-  box-shadow: 0 0 0 1px rgba(5,25,45,0.1);
-  -webkit-transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
-  transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25);
   position: fixed;
   left: 0;
   top: 8px;
@@ -16914,11 +16914,11 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at b
 }
 
 .emotion-2 {
-  background-color: rgb(255, 255, 255);
+  background-color: #ffffff;
   border-radius: 4px;
-  box-shadow: 0 0 0 1px rgba(5,25,45,0.1);
-  -webkit-transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
-  transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25);
   position: fixed;
   left: 0;
   top: 8px;
@@ -17047,11 +17047,11 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at l
 }
 
 .emotion-2 {
-  background-color: rgb(255, 255, 255);
+  background-color: #ffffff;
   border-radius: 4px;
-  box-shadow: 0 0 0 1px rgba(5,25,45,0.1);
-  -webkit-transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
-  transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25);
   position: fixed;
   left: -8px;
   top: 0;
@@ -17180,11 +17180,11 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at r
 }
 
 .emotion-2 {
-  background-color: rgb(255, 255, 255);
+  background-color: #ffffff;
   border-radius: 4px;
-  box-shadow: 0 0 0 1px rgba(5,25,45,0.1);
-  -webkit-transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
-  transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25);
   position: fixed;
   left: 8px;
   top: 0;
@@ -17313,11 +17313,11 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at t
 }
 
 .emotion-2 {
-  background-color: rgb(255, 255, 255);
+  background-color: #ffffff;
   border-radius: 4px;
-  box-shadow: 0 0 0 1px rgba(5,25,45,0.1);
-  -webkit-transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
-  transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25);
   position: fixed;
   left: 0;
   top: -8px;
@@ -17446,11 +17446,11 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at t
 }
 
 .emotion-2 {
-  background-color: rgb(255, 255, 255);
+  background-color: #ffffff;
   border-radius: 4px;
-  box-shadow: 0 0 0 1px rgba(5,25,45,0.1);
-  -webkit-transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
-  transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25);
   position: fixed;
   left: 0;
   top: -8px;
@@ -17579,11 +17579,11 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at t
 }
 
 .emotion-2 {
-  background-color: rgb(255, 255, 255);
+  background-color: #ffffff;
   border-radius: 4px;
-  box-shadow: 0 0 0 1px rgba(5,25,45,0.1);
-  -webkit-transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
-  transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25);
   position: fixed;
   left: 0;
   top: -8px;
@@ -17712,11 +17712,11 @@ exports[`<Button /> tooltips tooltip position snapshots renders the tooltip at u
 }
 
 .emotion-2 {
-  background-color: rgb(255, 255, 255);
+  background-color: #ffffff;
   border-radius: 4px;
-  box-shadow: 0 0 0 1px rgba(5,25,45,0.1);
-  -webkit-transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
-  transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25);
   position: fixed;
   left: 0;
   top: 8px;

--- a/packages/react-components/button/src/UserAccountMenu/AlertDot.tsx
+++ b/packages/react-components/button/src/UserAccountMenu/AlertDot.tsx
@@ -1,19 +1,12 @@
 import wafflesTokens from '@datacamp/waffles-tokens';
 import { css } from '@emotion/react';
 
-import { FULL_MENU_MEDIA_QUERY } from './constants';
-
 const dotStyle = css({
   backgroundColor: wafflesTokens.colors.red,
   border: `1px solid ${wafflesTokens.colors.white}`,
   borderRadius: 8,
-  [FULL_MENU_MEDIA_QUERY]: {
-    display: 'none',
-  },
   height: 8,
   position: 'absolute',
-  right: 0,
-  top: 0,
   width: 8,
   zIndex: 1,
 });

--- a/packages/react-components/button/src/UserAccountMenu/Button.tsx
+++ b/packages/react-components/button/src/UserAccountMenu/Button.tsx
@@ -41,6 +41,14 @@ const chevronStyle = css({
   },
 });
 
+const alertDotStyle = css({
+  [FULL_MENU_MEDIA_QUERY]: {
+    display: 'none',
+  },
+  right: 0,
+  top: 0,
+});
+
 type ButtonProps = {
   avatarUrl?: string;
   isOpen: boolean;
@@ -69,7 +77,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         ) : (
           <ChevronDownIcon aria-hidden={true} css={chevronStyle} />
         )}
-        {showAlertDot && <AlertDot />}
+        {showAlertDot && <AlertDot css={alertDotStyle} />}
       </button>
     );
   },

--- a/packages/react-components/button/src/UserAccountMenu/MenuItem.tsx
+++ b/packages/react-components/button/src/UserAccountMenu/MenuItem.tsx
@@ -3,6 +3,8 @@ import { css } from '@emotion/react';
 import { useFocusRing } from '@react-aria/focus';
 import { forwardRef } from 'react';
 
+import AlertDot from './AlertDot';
+
 const wrapperStyle = css({
   alignItems: 'center',
   display: 'flex',
@@ -28,6 +30,7 @@ const itemStyle = css({
   outline: 0,
   paddingLeft: 24,
   paddingRight: 24,
+  position: 'relative',
   textDecoration: 'none',
   userSelect: 'none',
   whiteSpace: 'nowrap',
@@ -39,6 +42,11 @@ const contentStyle = css({
   paddingLeft: 8,
 });
 
+const alertDotStyle = css({
+  left: 40,
+  top: 6,
+});
+
 type IconProps = {
   'aria-hidden'?: boolean;
   color?: string;
@@ -48,10 +56,14 @@ type IconProps = {
 type MenuItemProps = {
   children: React.ReactNode;
   icon: React.ComponentType<IconProps>;
+  showAlertDot?: boolean;
 } & React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 const MenuItem = forwardRef<HTMLAnchorElement, MenuItemProps>(
-  ({ children, className, icon: Icon, ...restProps }, ref) => {
+  (
+    { children, className, icon: Icon, showAlertDot = false, ...restProps },
+    ref,
+  ) => {
     const { focusProps, isFocusVisible } = useFocusRing();
 
     return (
@@ -68,6 +80,7 @@ const MenuItem = forwardRef<HTMLAnchorElement, MenuItemProps>(
           {...restProps}
           {...focusProps}
         >
+          {showAlertDot && <AlertDot css={alertDotStyle} />}
           <Icon aria-hidden={true} color="currentColor" size={18} />
           <span css={contentStyle}>{children}</span>
         </a>

--- a/packages/react-components/button/src/UserAccountMenu/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/button/src/UserAccountMenu/__snapshots__/index.spec.tsx.snap
@@ -95,11 +95,11 @@ exports[`UserAccountMenu snapshots renders correctly when all optional props are
 }
 
 .emotion-6 {
-  background-color: rgb(255, 255, 255);
+  background-color: #ffffff;
   border-radius: 4px;
-  box-shadow: 0px 0px 1px 0px rgba(5, 25, 45, 0.3),0 8px 12px -4px rgba(5,25,45,0.3);
-  -webkit-transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
-  transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25),0 8px 12px -4px rgba(5,25,45,0.3);
   overflow: hidden;
 }
 
@@ -181,6 +181,7 @@ exports[`UserAccountMenu snapshots renders correctly when all optional props are
   outline: 0;
   padding-left: 24px;
   padding-right: 24px;
+  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-user-select: none;
@@ -636,11 +637,11 @@ exports[`UserAccountMenu snapshots renders correctly when only main app URL is p
 }
 
 .emotion-6 {
-  background-color: rgb(255, 255, 255);
+  background-color: #ffffff;
   border-radius: 4px;
-  box-shadow: 0px 0px 1px 0px rgba(5, 25, 45, 0.3),0 8px 12px -4px rgba(5,25,45,0.3);
-  -webkit-transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
-  transition: all 0.6s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
+  box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25),0 8px 12px -4px rgba(5,25,45,0.3);
   overflow: hidden;
 }
 
@@ -686,6 +687,7 @@ exports[`UserAccountMenu snapshots renders correctly when only main app URL is p
   outline: 0;
   padding-left: 24px;
   padding-right: 24px;
+  position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-user-select: none;

--- a/packages/react-components/button/src/UserAccountMenu/index.spec.tsx
+++ b/packages/react-components/button/src/UserAccountMenu/index.spec.tsx
@@ -2,7 +2,7 @@
 import '@testing-library/jest-dom/extend-expect';
 
 import { AddCircleIcon } from '@datacamp/waffles-icons';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor, within } from '@testing-library/react';
 
 import UserAccountMenu from './index';
 
@@ -145,6 +145,7 @@ describe('UserAccountMenu', () => {
         <UserAccountMenu.MenuItem
           href="https://help.com/help"
           icon={AddCircleIcon}
+          showAlertDot
         >
           Get Help
         </UserAccountMenu.MenuItem>
@@ -156,6 +157,10 @@ describe('UserAccountMenu', () => {
     const logoutLink = getByText('Log Out').closest('a');
     const infoLink = getByText('Additional Info').closest('a');
     const helpLink = getByText('Get Help').closest('a');
+    let alertDot;
+    if (helpLink) {
+      alertDot = within(helpLink).getByTestId('user-account-menu-alert-dot');
+    }
 
     expect(accountSettingsLink).toBeInTheDocument();
     expect(logoutLink).toBeInTheDocument();
@@ -163,6 +168,7 @@ describe('UserAccountMenu', () => {
     expect(infoLink).toHaveAttribute('href', 'https://info.com');
     expect(helpLink).toBeInTheDocument();
     expect(helpLink).toHaveAttribute('href', 'https://help.com/help');
+    expect(alertDot).toBeInTheDocument();
   });
 
   it("when custom menu item is clicked it's onClick handler is called", () => {


### PR DESCRIPTION
## Proposed changes
Added a possibility to show notification icon after passing **showAlertDot** prop to **MenuItem**:

<img width="318" alt="Screenshot 2021-06-14 at 10 30 19" src="https://user-images.githubusercontent.com/20565536/121863078-c215d380-ccfb-11eb-9d20-21ae1a3b0318.png">

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [ ] ~~Migration plan for breaking changes~~

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] ~~Approved by Designer, Engineer, & PO~~
