### PR TITLE
[FIX] Revert  usage of fromEntries

### DIFF
--- a/packages/other/utils/src/computeDataAttributes.spec.ts
+++ b/packages/other/utils/src/computeDataAttributes.spec.ts
@@ -1,20 +1,25 @@
 import computeDataAttributes from './computeDataAttributes';
 
 describe('computeDataAttributes', () => {
-  it('returns an empty object when input undefined', () => {
+  it('returns an empty object when input is undefined', () => {
     expect(computeDataAttributes()).toEqual({});
   });
 
-  it('returns an empty object when input an empty object', () => {
+  it('returns an empty object when input is an empty object', () => {
     expect(computeDataAttributes({})).toEqual({});
   });
 
   it('returns an the correct data attributes', () => {
     expect(
-      computeDataAttributes({ test: 'example', test2: 'other example' }),
+      computeDataAttributes({
+        test: 'example',
+        test2: 'other example',
+        testid: 'submit-button',
+      }),
     ).toEqual({
       'data-test': 'example',
       'data-test2': 'other example',
+      'data-testid': 'submit-button',
     });
   });
 });

--- a/packages/other/utils/src/computeDataAttributes.ts
+++ b/packages/other/utils/src/computeDataAttributes.ts
@@ -12,11 +12,15 @@ const computeDataAttributes = (
     return {};
   }
 
-  return Object.fromEntries(
-    Object.entries(dataAttributes).map((entry) => {
+  return Object.entries(dataAttributes).reduce<DataAttributes>(
+    (updatedEntries, entry) => {
       const [key, value] = entry;
-      return [`data-${key}`, value];
-    }),
+      return {
+        ...updatedEntries,
+        [`data-${key}`]: value,
+      };
+    },
+    {},
   );
 };
 

--- a/packages/other/utils/src/computeDataAttributes.ts
+++ b/packages/other/utils/src/computeDataAttributes.ts
@@ -12,9 +12,9 @@ const computeDataAttributes = (
     return {};
   }
 
-  return Object.entries(dataAttributes).reduce<DataAttributes>(
-    (updatedEntries, entry) => {
-      const [key, value] = entry;
+  return Object.keys(dataAttributes).reduce<DataAttributes>(
+    (updatedEntries, key) => {
+      const value = dataAttributes[key];
       return {
         ...updatedEntries,
         [`data-${key}`]: value,

--- a/packages/react-components/button/src/Button/buttonStyles.ts
+++ b/packages/react-components/button/src/Button/buttonStyles.ts
@@ -29,16 +29,15 @@ const primaryHoverColors: IntentMap = {
   warning: tokens.color.primary.orangeLight.value.hex,
 };
 
-const outlineHoverColors: IntentMap = Object.entries(baseColors).reduce(
-  (hoverColors, baseColor) => {
-    const [intent, value] = baseColor;
-    return {
-      ...hoverColors,
-      [intent]: hexToRgbaColor(value, 0.15),
-    };
-  },
-  {} as IntentMap,
-);
+const outlineHoverColors = (Object.keys(baseColors) as Array<
+  keyof typeof baseColors
+>).reduce((hoverColors, intent) => {
+  const value = baseColors[intent];
+  return {
+    ...hoverColors,
+    [intent]: hexToRgbaColor(value, 0.15),
+  };
+}, {} as IntentMap);
 
 // BASE STYLES
 const baseStyle = css({


### PR DESCRIPTION
## Proposed changes

Because of some errors reported by Sentry replaced **fromEntries** with regular reduce, for better old browser support.
Used `Object.keys` in the refactor, which is supported by IE11.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [ ] ~~Technical docs written~~
- [ ] ~~Structural changes reflected in Readme~~
- [ ] ~~Migration plan for breaking changes~~

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [ ] ~~Approved by Designer, Engineer, & PO~~
