### PR TITLE
[WF-511] Update Icons sizes

### DIFF
--- a/packages/docs/next-doc-site/examples/icons/customized.tsx
+++ b/packages/docs/next-doc-site/examples/icons/customized.tsx
@@ -2,7 +2,7 @@ import { AddCircleIcon } from '@datacamp/waffles-icons';
 import tokens from '@datacamp/waffles-tokens';
 
 function Example(): JSX.Element {
-  return <AddCircleIcon color={tokens.colors.green} size={24} />;
+  return <AddCircleIcon color={tokens.colors.purple} size="small" />;
 }
 
 export default Example;

--- a/packages/docs/next-doc-site/pages/components/icons.mdx
+++ b/packages/docs/next-doc-site/pages/components/icons.mdx
@@ -31,7 +31,7 @@ import { AddCircleIcon } from '@datacamp/waffles-icons';
 
 All these components accept the same set of properties:
 
-- **size** – The size in pixels to display the icon. The default is `18`. Possible values: `12`, `18`, and `24`.
+- **size** – The size of an icon. The default is `medium`. Possible values: `medium`, `small`, and `xsmall`.
 - **color** – The color of the icon. This defaults to _currentColor_, and so will match the surrounding text. If a custom color is required, then this prop can accept any valid CSS color. We recommend using the [waffles-tokens](/components/tokens) to maintain a consistent visual experience.
 - **className** – Any extra className to pass to the root svg element. Can be used to apply any extra custom styling required.
 

--- a/packages/docs/storybook/stories/icons.stories.js
+++ b/packages/docs/storybook/stories/icons.stories.js
@@ -15,13 +15,13 @@ storiesOf('waffles-icons', module)
               <Text>{name}</Text>
             </td>
             <td>
-              <Component color={color('color', 'currentColor')} size={12} />
+              <Component color={color('color', 'currentColor')} size="xsmall" />
             </td>
             <td>
-              <Component color={color('color', 'currentColor')} size={18} />
+              <Component color={color('color', 'currentColor')} size="small" />
             </td>
             <td>
-              <Component color={color('color', 'currentColor')} size={24} />
+              <Component color={color('color', 'currentColor')} size="medium" />
             </td>
           </tr>
         ))}

--- a/packages/react-components/button/src/Button/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/button/src/Button/__snapshots__/index.spec.tsx.snap
@@ -16167,10 +16167,10 @@ exports[`<Button /> snapshots renders a squared button with a single icon 1`] = 
 >
   <svg
     aria-hidden="true"
-    height="18"
+    height="16"
     role="img"
     viewBox="0 0 18 18"
-    width="18"
+    width="16"
   >
     <path
       d="M9 16A7 7 0 109 2a7 7 0 000 14zm0 2A9 9 0 119 0a9 9 0 010 18zm1-10h3a1 1 0 010 2h-3v3a1 1 0 01-2 0v-3H5a1 1 0 110-2h3V5a1 1 0 112 0v3z"

--- a/packages/react-components/button/src/Button/index.tsx
+++ b/packages/react-components/button/src/Button/index.tsx
@@ -289,7 +289,7 @@ const InternalButton = (
             React.cloneElement(child, {
               'aria-hidden': true, // hide icon from screen reader so only ariaLabel or button text is read.
               color: loading ? 'transparent' : child.props.color ?? iconColor,
-              size: size === 'large' ? 24 : 18,
+              size: 'medium',
               title: '', // remove tooltip from icon within button
             })
           ),

--- a/packages/react-components/button/src/CloseButton/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/button/src/CloseButton/__snapshots__/index.spec.tsx.snap
@@ -57,10 +57,10 @@ exports[`CloseButton renders the close button 1`] = `
 >
   <svg
     aria-hidden="true"
-    height="18"
+    height="16"
     role="img"
     viewBox="0 0 18 18"
-    width="18"
+    width="16"
   >
     <title>
       Cross

--- a/packages/react-components/button/src/CloseButton/index.tsx
+++ b/packages/react-components/button/src/CloseButton/index.tsx
@@ -1,7 +1,6 @@
 import { CrossIcon } from '@datacamp/waffles-icons';
 import tokens from '@datacamp/waffles-tokens';
 import { css } from '@emotion/react';
-import React from 'react';
 
 type CloseButtonProps = {
   className?: string;
@@ -46,7 +45,7 @@ const CloseButton = ({
     onClick={onClick}
     type="button"
   >
-    <CrossIcon aria-hidden size={size === 'large' ? 18 : 12} />
+    <CrossIcon aria-hidden size="medium" />
   </button>
 );
 

--- a/packages/react-components/button/src/SocialMediaButtons/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/button/src/SocialMediaButtons/__snapshots__/index.spec.tsx.snap
@@ -86,10 +86,10 @@ exports[`Social Media Buttons renders facebook button 1`] = `
 >
   <svg
     aria-hidden="true"
-    height="18"
+    height="16"
     role="img"
     viewBox="0 0 18 18"
-    width="18"
+    width="16"
   >
     <path
       d="M18 9c0-4.968-4.032-9-9-9S0 4.032 0 9a8.99 8.99 0 007.6 8.889v-6.294H5.302V9H7.6V7.016c0-2.252 1.335-3.503 3.393-3.503.982 0 2.002.185 2.002.185v2.197h-1.13c-1.122 0-1.475.704-1.475 1.409V8.99h2.503l-.399 2.595H10.39v6.294A8.974 8.974 0 0018 9z"
@@ -191,10 +191,10 @@ exports[`Social Media Buttons renders google button 1`] = `
 >
   <svg
     aria-hidden="true"
-    height="18"
+    height="16"
     role="img"
     viewBox="0 0 18 18"
-    width="18"
+    width="16"
   >
     <g
       fill="none"
@@ -312,10 +312,10 @@ exports[`Social Media Buttons renders linked in button 1`] = `
 >
   <svg
     aria-hidden="true"
-    height="18"
+    height="16"
     role="img"
     viewBox="0 0 18 18"
-    width="18"
+    width="16"
   >
     <path
       d="M4 2c0 1.1-.7 2-2 2-1.2 0-2-.9-2-1.9C0 1 .8 0 2 0s2 .9 2 2zM0 18h4V5H0v13zM13.6 5.2c-2.1 0-3.3 1.2-3.8 2h-.1l-.2-1.7H5.9c0 1.1.1 2.4.1 3.9V18h4v-7.1c0-.4 0-.7.1-1 .3-.7.8-1.6 1.9-1.6 1.4 0 2 1.2 2 2.8V18h4v-7.4c0-3.7-1.9-5.4-4.4-5.4z"
@@ -417,10 +417,10 @@ exports[`Social Media Buttons renders twitter button 1`] = `
 >
   <svg
     aria-hidden="true"
-    height="18"
+    height="16"
     role="img"
     viewBox="0 0 18 18"
-    width="18"
+    width="16"
   >
     <path
       d="M15.864 5.35c.008.146.01.293.01.439 0 4.491-3.417 9.668-9.666 9.668A9.61 9.61 0 011 13.93c.266.031.536.047.81.047a6.819 6.819 0 004.22-1.453 3.4 3.4 0 01-3.174-2.36 3.472 3.472 0 001.534-.058 3.4 3.4 0 01-2.725-3.332V6.73a3.39 3.39 0 001.54.426A3.397 3.397 0 012.152 2.62a9.644 9.644 0 007.003 3.55A3.396 3.396 0 0112.466 2c.977 0 1.86.411 2.48 1.072a6.842 6.842 0 002.157-.825 3.41 3.41 0 01-1.494 1.88 6.796 6.796 0 001.951-.535 6.86 6.86 0 01-1.696 1.758z"

--- a/packages/react-components/button/src/UserAccountMenu/MenuItem.tsx
+++ b/packages/react-components/button/src/UserAccountMenu/MenuItem.tsx
@@ -50,7 +50,7 @@ const alertDotStyle = css({
 type IconProps = {
   'aria-hidden'?: boolean;
   color?: string;
-  size?: 12 | 18 | 24;
+  size?: 'xsmall' | 'small' | 'medium';
 };
 
 type MenuItemProps = {
@@ -81,7 +81,7 @@ const MenuItem = forwardRef<HTMLAnchorElement, MenuItemProps>(
           {...focusProps}
         >
           {showAlertDot && <AlertDot css={alertDotStyle} />}
-          <Icon aria-hidden={true} color="currentColor" size={18} />
+          <Icon aria-hidden={true} color="currentColor" size="medium" />
           <span css={contentStyle}>{children}</span>
         </a>
       </li>

--- a/packages/react-components/button/src/UserAccountMenu/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/button/src/UserAccountMenu/__snapshots__/index.spec.tsx.snap
@@ -243,10 +243,10 @@ exports[`UserAccountMenu snapshots renders correctly when all optional props are
     <svg
       aria-hidden="true"
       class="emotion-4"
-      height="18"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="16"
     >
       <title>
         Chevron Up
@@ -290,10 +290,10 @@ exports[`UserAccountMenu snapshots renders correctly when all optional props are
           >
             <svg
               aria-hidden="true"
-              height="18"
+              height="16"
               role="img"
               viewBox="0 0 18 18"
-              width="18"
+              width="16"
             >
               <title>
                 User
@@ -324,10 +324,10 @@ exports[`UserAccountMenu snapshots renders correctly when all optional props are
           >
             <svg
               aria-hidden="true"
-              height="18"
+              height="16"
               role="img"
               viewBox="0 0 18 18"
-              width="18"
+              width="16"
             >
               <title>
                 Cog
@@ -357,10 +357,10 @@ exports[`UserAccountMenu snapshots renders correctly when all optional props are
           >
             <svg
               aria-hidden="true"
-              height="18"
+              height="16"
               role="img"
               viewBox="0 0 18 18"
-              width="18"
+              width="16"
             >
               <title>
                 Add
@@ -391,10 +391,10 @@ exports[`UserAccountMenu snapshots renders correctly when all optional props are
           >
             <svg
               aria-hidden="true"
-              height="18"
+              height="16"
               role="img"
               viewBox="0 0 18 18"
-              width="18"
+              width="16"
             >
               <title>
                 Exit
@@ -524,10 +524,10 @@ exports[`UserAccountMenu snapshots renders correctly when only main app URL is p
     <svg
       aria-hidden="true"
       class="emotion-4"
-      height="18"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="16"
     >
       <title>
         Down Chevron
@@ -748,10 +748,10 @@ exports[`UserAccountMenu snapshots renders correctly when only main app URL is p
     <svg
       aria-hidden="true"
       class="emotion-4"
-      height="18"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="16"
     >
       <title>
         Chevron Up
@@ -785,10 +785,10 @@ exports[`UserAccountMenu snapshots renders correctly when only main app URL is p
           >
             <svg
               aria-hidden="true"
-              height="18"
+              height="16"
               role="img"
               viewBox="0 0 18 18"
-              width="18"
+              width="16"
             >
               <title>
                 Cog
@@ -818,10 +818,10 @@ exports[`UserAccountMenu snapshots renders correctly when only main app URL is p
           >
             <svg
               aria-hidden="true"
-              height="18"
+              height="16"
               role="img"
               viewBox="0 0 18 18"
-              width="18"
+              width="16"
             >
               <title>
                 Exit

--- a/packages/react-components/form-elements/src/CheckboxList/CheckboxIcon.tsx
+++ b/packages/react-components/form-elements/src/CheckboxList/CheckboxIcon.tsx
@@ -35,7 +35,7 @@ const CheckboxIcon: React.FC<{
         {checked && (
           <CheckmarkIcon
             aria-hidden={true} // Hide this icon, as label and input element are sufficient
-            size={12}
+            size="small"
             title="" // Remove the title, as label and input element are sufficient
           />
         )}

--- a/packages/react-components/form-elements/src/CheckboxList/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/form-elements/src/CheckboxList/__snapshots__/index.spec.tsx.snap
@@ -212,10 +212,10 @@ exports[`<CheckboxList> snapshots renders a checkbox list 1`] = `
       >
         <svg
           aria-hidden="true"
-          height="12"
+          height="14"
           role="img"
           viewBox="0 0 18 18"
-          width="12"
+          width="14"
         >
           <path
             d="M13.746 4.337a1.015 1.015 0 011.409-.099c.417.354.462.97.101 1.378l-7.13 8.047a1.015 1.015 0 01-1.483.03L2.771 9.67a.961.961 0 01.044-1.38 1.015 1.015 0 011.412.041l3.113 3.235 6.406-7.229z"

--- a/packages/react-components/form-elements/src/Input/index.tsx
+++ b/packages/react-components/form-elements/src/Input/index.tsx
@@ -230,7 +230,11 @@ const InternalInput = ({
       type="button"
     >
       <i aria-hidden="true">
-        {passwordVisible ? <HiddenIcon size={24} /> : <VisibleIcon size={24} />}
+        {passwordVisible ? (
+          <HiddenIcon size="medium" />
+        ) : (
+          <VisibleIcon size="medium" />
+        )}
       </i>
     </button>
   );

--- a/packages/react-components/form-elements/src/Select/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/form-elements/src/Select/__snapshots__/index.spec.tsx.snap
@@ -122,7 +122,7 @@ exports[`with label snapshots renders a select element with size large, disabled
   pointer-events: none;
   position: absolute;
   right: 24px;
-  top: 20px;
+  top: 22px;
   opacity: 1;
 }
 
@@ -192,10 +192,10 @@ exports[`with label snapshots renders a select element with size large, disabled
     <svg
       aria-hidden="false"
       class="emotion-8"
-      height="24"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="24"
+      width="16"
     >
       <title>
         Down Chevron
@@ -348,7 +348,7 @@ exports[`with label snapshots renders a select element with size large, disabled
   pointer-events: none;
   position: absolute;
   right: 24px;
-  top: 20px;
+  top: 22px;
   opacity: 1;
 }
 
@@ -423,10 +423,10 @@ exports[`with label snapshots renders a select element with size large, disabled
     <svg
       aria-hidden="false"
       class="emotion-9"
-      height="24"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="24"
+      width="16"
     >
       <title>
         Down Chevron
@@ -549,7 +549,7 @@ exports[`with label snapshots renders a select element with size large, disabled
   pointer-events: none;
   position: absolute;
   right: 24px;
-  top: 20px;
+  top: 22px;
   opacity: 1;
 }
 
@@ -610,10 +610,10 @@ exports[`with label snapshots renders a select element with size large, disabled
     <svg
       aria-hidden="false"
       class="emotion-6"
-      height="24"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="24"
+      width="16"
     >
       <title>
         Down Chevron
@@ -755,7 +755,7 @@ exports[`with label snapshots renders a select element with size large, disabled
   pointer-events: none;
   position: absolute;
   right: 24px;
-  top: 20px;
+  top: 22px;
   opacity: 0.3;
 }
 
@@ -826,10 +826,10 @@ exports[`with label snapshots renders a select element with size large, disabled
     <svg
       aria-hidden="false"
       class="emotion-8"
-      height="24"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="24"
+      width="16"
     >
       <title>
         Down Chevron
@@ -982,7 +982,7 @@ exports[`with label snapshots renders a select element with size large, disabled
   pointer-events: none;
   position: absolute;
   right: 24px;
-  top: 20px;
+  top: 22px;
   opacity: 0.3;
 }
 
@@ -1058,10 +1058,10 @@ exports[`with label snapshots renders a select element with size large, disabled
     <svg
       aria-hidden="false"
       class="emotion-9"
-      height="24"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="24"
+      width="16"
     >
       <title>
         Down Chevron
@@ -1184,7 +1184,7 @@ exports[`with label snapshots renders a select element with size large, disabled
   pointer-events: none;
   position: absolute;
   right: 24px;
-  top: 20px;
+  top: 22px;
   opacity: 0.3;
 }
 
@@ -1246,10 +1246,10 @@ exports[`with label snapshots renders a select element with size large, disabled
     <svg
       aria-hidden="false"
       class="emotion-6"
-      height="24"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="24"
+      width="16"
     >
       <title>
         Down Chevron
@@ -1391,7 +1391,7 @@ exports[`with label snapshots renders a select element with size medium, disable
   pointer-events: none;
   position: absolute;
   right: 16px;
-  top: 15px;
+  top: 17px;
   opacity: 1;
 }
 
@@ -1461,10 +1461,10 @@ exports[`with label snapshots renders a select element with size medium, disable
     <svg
       aria-hidden="false"
       class="emotion-8"
-      height="18"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="16"
     >
       <title>
         Down Chevron
@@ -1617,7 +1617,7 @@ exports[`with label snapshots renders a select element with size medium, disable
   pointer-events: none;
   position: absolute;
   right: 16px;
-  top: 15px;
+  top: 17px;
   opacity: 1;
 }
 
@@ -1692,10 +1692,10 @@ exports[`with label snapshots renders a select element with size medium, disable
     <svg
       aria-hidden="false"
       class="emotion-9"
-      height="18"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="16"
     >
       <title>
         Down Chevron
@@ -1818,7 +1818,7 @@ exports[`with label snapshots renders a select element with size medium, disable
   pointer-events: none;
   position: absolute;
   right: 16px;
-  top: 15px;
+  top: 17px;
   opacity: 1;
 }
 
@@ -1879,10 +1879,10 @@ exports[`with label snapshots renders a select element with size medium, disable
     <svg
       aria-hidden="false"
       class="emotion-6"
-      height="18"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="16"
     >
       <title>
         Down Chevron
@@ -2024,7 +2024,7 @@ exports[`with label snapshots renders a select element with size medium, disable
   pointer-events: none;
   position: absolute;
   right: 16px;
-  top: 15px;
+  top: 17px;
   opacity: 0.3;
 }
 
@@ -2095,10 +2095,10 @@ exports[`with label snapshots renders a select element with size medium, disable
     <svg
       aria-hidden="false"
       class="emotion-8"
-      height="18"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="16"
     >
       <title>
         Down Chevron
@@ -2251,7 +2251,7 @@ exports[`with label snapshots renders a select element with size medium, disable
   pointer-events: none;
   position: absolute;
   right: 16px;
-  top: 15px;
+  top: 17px;
   opacity: 0.3;
 }
 
@@ -2327,10 +2327,10 @@ exports[`with label snapshots renders a select element with size medium, disable
     <svg
       aria-hidden="false"
       class="emotion-9"
-      height="18"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="16"
     >
       <title>
         Down Chevron
@@ -2453,7 +2453,7 @@ exports[`with label snapshots renders a select element with size medium, disable
   pointer-events: none;
   position: absolute;
   right: 16px;
-  top: 15px;
+  top: 17px;
   opacity: 0.3;
 }
 
@@ -2515,10 +2515,10 @@ exports[`with label snapshots renders a select element with size medium, disable
     <svg
       aria-hidden="false"
       class="emotion-6"
-      height="18"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="16"
     >
       <title>
         Down Chevron
@@ -2660,7 +2660,7 @@ exports[`with label snapshots renders a select element with size small, disabled
   pointer-events: none;
   position: absolute;
   right: 12px;
-  top: 9px;
+  top: 11px;
   opacity: 1;
 }
 
@@ -2730,10 +2730,10 @@ exports[`with label snapshots renders a select element with size small, disabled
     <svg
       aria-hidden="false"
       class="emotion-8"
-      height="18"
+      height="14"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="14"
     >
       <title>
         Down Chevron
@@ -2886,7 +2886,7 @@ exports[`with label snapshots renders a select element with size small, disabled
   pointer-events: none;
   position: absolute;
   right: 12px;
-  top: 9px;
+  top: 11px;
   opacity: 1;
 }
 
@@ -2961,10 +2961,10 @@ exports[`with label snapshots renders a select element with size small, disabled
     <svg
       aria-hidden="false"
       class="emotion-9"
-      height="18"
+      height="14"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="14"
     >
       <title>
         Down Chevron
@@ -3087,7 +3087,7 @@ exports[`with label snapshots renders a select element with size small, disabled
   pointer-events: none;
   position: absolute;
   right: 12px;
-  top: 9px;
+  top: 11px;
   opacity: 1;
 }
 
@@ -3148,10 +3148,10 @@ exports[`with label snapshots renders a select element with size small, disabled
     <svg
       aria-hidden="false"
       class="emotion-6"
-      height="18"
+      height="14"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="14"
     >
       <title>
         Down Chevron
@@ -3293,7 +3293,7 @@ exports[`with label snapshots renders a select element with size small, disabled
   pointer-events: none;
   position: absolute;
   right: 12px;
-  top: 9px;
+  top: 11px;
   opacity: 0.3;
 }
 
@@ -3364,10 +3364,10 @@ exports[`with label snapshots renders a select element with size small, disabled
     <svg
       aria-hidden="false"
       class="emotion-8"
-      height="18"
+      height="14"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="14"
     >
       <title>
         Down Chevron
@@ -3520,7 +3520,7 @@ exports[`with label snapshots renders a select element with size small, disabled
   pointer-events: none;
   position: absolute;
   right: 12px;
-  top: 9px;
+  top: 11px;
   opacity: 0.3;
 }
 
@@ -3596,10 +3596,10 @@ exports[`with label snapshots renders a select element with size small, disabled
     <svg
       aria-hidden="false"
       class="emotion-9"
-      height="18"
+      height="14"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="14"
     >
       <title>
         Down Chevron
@@ -3722,7 +3722,7 @@ exports[`with label snapshots renders a select element with size small, disabled
   pointer-events: none;
   position: absolute;
   right: 12px;
-  top: 9px;
+  top: 11px;
   opacity: 0.3;
 }
 
@@ -3784,10 +3784,10 @@ exports[`with label snapshots renders a select element with size small, disabled
     <svg
       aria-hidden="false"
       class="emotion-6"
-      height="18"
+      height="14"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="14"
     >
       <title>
         Down Chevron

--- a/packages/react-components/form-elements/src/Switch/Toggle.tsx
+++ b/packages/react-components/form-elements/src/Switch/Toggle.tsx
@@ -80,7 +80,7 @@ function Toggle({
           <CheckmarkIcon
             aria-hidden={true}
             color={tokens.colors.blue}
-            size={12}
+            size="small"
           />
         )}
       </div>

--- a/packages/react-components/form-elements/src/Switch/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/form-elements/src/Switch/__snapshots__/index.spec.tsx.snap
@@ -947,10 +947,10 @@ exports[`snapshots renders an empty switch 1`] = `
     >
       <svg
         aria-hidden="true"
-        height="12"
+        height="14"
         role="img"
         viewBox="0 0 18 18"
-        width="12"
+        width="14"
       >
         <title>
           Checkmark

--- a/packages/react-components/form-elements/src/formStyles.ts
+++ b/packages/react-components/form-elements/src/formStyles.ts
@@ -95,22 +95,22 @@ const inputWithIconPaddings = {
   small: { padding: `0 ${tokens.size.space[36].value}px` },
 };
 
-const selectIconSizes: { [key: string]: 18 | 24 } = {
-  large: 24,
-  medium: 18,
-  small: 18,
+const selectIconSizes: { [key: string]: 'medium' | 'small' } = {
+  large: 'medium',
+  medium: 'medium',
+  small: 'small',
 };
 
 const iconSize = {
-  large: 24,
-  medium: 18,
-  small: 12,
+  large: 16,
+  medium: 16,
+  small: 14,
 };
 
 const arrowIconPosition = {
-  large: { right: tokens.size.space[24].value, top: '20px' },
-  medium: { right: tokens.size.space[16].value, top: '15px' },
-  small: { right: tokens.size.space[12].value, top: '9px' },
+  large: { right: tokens.size.space[24].value, top: '22px' },
+  medium: { right: tokens.size.space[16].value, top: '17px' },
+  small: { right: tokens.size.space[12].value, top: '11px' },
 };
 
 const requiredStyle = css({

--- a/packages/react-components/icons/gulpfile.js
+++ b/packages/react-components/icons/gulpfile.js
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable sonarjs/no-identical-functions */
 /* eslint-disable no-param-reassign */
 const { dest, parallel, series, src } = require('gulp');
@@ -54,10 +55,10 @@ function buildTypescriptWebComponents() {
           svgProps: {
             'aria-hidden': '{ariaHidden}',
             className: '{className}',
-            height: '{size}',
+            height: '{numericSize}',
             ref: '{ref}',
             role: 'img',
-            width: '{size}',
+            width: '{numericSize}',
           },
           template({ template }, opts, { jsx }) {
             const typescriptTemplate = template.smart({
@@ -70,7 +71,7 @@ function buildTypescriptWebComponents() {
               'aria-hidden'?: boolean;
               className?: string;
               color?: string;
-              size?: 12 | 18 | 24;
+              size?: 'xsmall' | 'small' | 'medium';
               title?: string;
               titleId?: string;
             }
@@ -80,12 +81,12 @@ function buildTypescriptWebComponents() {
                   'aria-hidden': ariaHidden = false,
                   className,
                   color = 'currentColor',
-                  size = 18,
+                  size = 'medium',
                   title,
                   titleId
                 }: IconProps,
                 ref: React.Ref<SVGSVGElement>
-              ) => ${jsx})
+              ) => { const numericSize = size === 'medium' ? 16 : size === 'small' ? 14 : 12; return ${jsx}})
               export default ${componentName};
             `;
           },
@@ -114,9 +115,9 @@ function buildTypescriptMobileComponents() {
           ...commonSVGRConfig,
           native: true,
           svgProps: {
-            height: '{size}',
+            height: '{numericSize}',
             style: '{style}',
-            width: '{size}',
+            width: '{numericSize}',
           },
           template({ template }, opts, { jsx }) {
             const typescriptTemplate = template.smart({
@@ -128,12 +129,12 @@ function buildTypescriptMobileComponents() {
               import Svg, { Path } from 'react-native-svg';
 
               interface IconProps {
-                color?: string,
-                size?: number,
-                style?: StyleProp<ViewStyle>
+                color?: string;
+                size?: 'xsmall' | 'small' | 'medium';
+                style?: StyleProp<ViewStyle>;
               }
 
-              const ${componentName} = ({size = 18, color = 'white', style}: IconProps) => ${jsx};
+              const ${componentName} = ({size = 'medium', color = 'white', style}: IconProps) => {const numericSize = size === 'medium' ? 16 : size === 'small' ? 14 : 12; return ${jsx}};
               export default ${componentName};
             `;
           },

--- a/packages/react-components/markdown/src/components/__snapshots__/Markdown.spec.tsx.snap
+++ b/packages/react-components/markdown/src/components/__snapshots__/Markdown.spec.tsx.snap
@@ -173,6 +173,7 @@ exports[`<Markdown /> renders 1`] = `
   background-color: #efebe4;
   margin: 0 2px;
   padding: 2px 4px;
+  white-space: nowrap;
 }
 
 .emotion-47 {
@@ -182,10 +183,7 @@ exports[`<Markdown /> renders 1`] = `
   line-height: 20px;
   margin: 0;
   overflow: scroll;
-  padding-bottom: 8px;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 8px;
+  padding: 4px 8px;
 }
 
 *:not(style)~.emotion-47 {

--- a/packages/react-components/modals/src/AlertDialog/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/AlertDialog/__snapshots__/index.spec.tsx.snap
@@ -418,10 +418,10 @@ exports[`<AlertModal /> isOpen renders the modal via a portal when true 1`] = `
         >
           <svg
             aria-hidden="true"
-            height="18"
+            height="16"
             role="img"
             viewBox="0 0 18 18"
-            width="18"
+            width="16"
           >
             <title>
               Cross

--- a/packages/react-components/modals/src/Dialog/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/Dialog/__snapshots__/index.spec.tsx.snap
@@ -194,10 +194,10 @@ exports[`<Dialog /> isOpen renders the modal via a portal when true 1`] = `
         >
           <svg
             aria-hidden="true"
-            height="18"
+            height="16"
             role="img"
             viewBox="0 0 18 18"
-            width="18"
+            width="16"
           >
             <title>
               Cross

--- a/packages/react-components/modals/src/Panel/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/Panel/__snapshots__/index.spec.tsx.snap
@@ -180,10 +180,10 @@ exports[`<Panel /> isOpen renders the modal via a portal when true 1`] = `
         >
           <svg
             aria-hidden="true"
-            height="18"
+            height="16"
             role="img"
             viewBox="0 0 18 18"
-            width="18"
+            width="16"
           >
             <title>
               Cross

--- a/packages/react-components/text/src/components/Code.tsx
+++ b/packages/react-components/text/src/components/Code.tsx
@@ -25,6 +25,7 @@ const style = css(codeStyle, {
   backgroundColor: tokens.colors.beige,
   margin: '0 2px',
   padding: '2px 4px',
+  whiteSpace: 'nowrap',
 });
 
 const Code = ({

--- a/packages/react-components/text/src/components/CodeBlock.tsx
+++ b/packages/react-components/text/src/components/CodeBlock.tsx
@@ -31,10 +31,7 @@ const preStyle = css({
   lineHeight: tokens.lineHeights.medium,
   margin: 0,
   overflow: 'scroll',
-  paddingBottom: tokens.spacing.small,
-  paddingLeft: 12,
-  paddingRight: 12,
-  paddingTop: tokens.spacing.small,
+  padding: `${tokens.spacing.xsmall} ${tokens.spacing.small}`,
   [ssrSafeNotFirstChildSelector]: {
     marginTop: 12,
   },

--- a/packages/react-components/text/src/components/__snapshots__/Code.spec.tsx.snap
+++ b/packages/react-components/text/src/components/__snapshots__/Code.spec.tsx.snap
@@ -15,6 +15,7 @@ exports[`snapshots renders 1`] = `
   background-color: #efebe4;
   margin: 0 2px;
   padding: 2px 4px;
+  white-space: nowrap;
 }
 
 <code

--- a/packages/react-components/text/src/components/__snapshots__/CodeBlock.spec.tsx.snap
+++ b/packages/react-components/text/src/components/__snapshots__/CodeBlock.spec.tsx.snap
@@ -8,10 +8,7 @@ exports[`<CodeBlock /> snapshots renders 1`] = `
   line-height: 20px;
   margin: 0;
   overflow: scroll;
-  padding-bottom: 8px;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 8px;
+  padding: 4px 8px;
 }
 
 *:not(style)~.emotion-0 {

--- a/packages/react-components/toast/src/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/toast/src/__snapshots__/index.spec.tsx.snap
@@ -122,10 +122,10 @@ exports[`toast mounts a success toast 1`] = `
     <svg
       aria-hidden="false"
       class="emotion-1"
-      height="18"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="16"
     >
       <title>
         success
@@ -152,10 +152,10 @@ exports[`toast mounts a success toast 1`] = `
     >
       <svg
         aria-hidden="true"
-        height="12"
+        height="16"
         role="img"
         viewBox="0 0 18 18"
-        width="12"
+        width="16"
       >
         <title>
           Cross
@@ -293,10 +293,10 @@ exports[`toast mounts an error toast 1`] = `
     <svg
       aria-hidden="false"
       class="emotion-1"
-      height="18"
+      height="16"
       role="img"
       viewBox="0 0 18 18"
-      width="18"
+      width="16"
     >
       <title>
         error
@@ -323,10 +323,10 @@ exports[`toast mounts an error toast 1`] = `
     >
       <svg
         aria-hidden="true"
-        height="12"
+        height="16"
         role="img"
         viewBox="0 0 18 18"
-        width="12"
+        width="16"
       >
         <title>
           Cross


### PR DESCRIPTION
# [WF-511](https://datacamp.atlassian.net/browse/WF-511)

## Proposed changes

Updated Waffles **Icons** sizes according to design guidelines:
- replace previous numeric values `12`, `18`, `24` with `xsmall`, `small`, and `medium` (which map to 12, 14, and 16px), to stay in line with new design tokens naming convention
- update all relevant components to use new icons
- update docs

Screenshot (icons medium size):
<img width="977" alt="Screenshot 2021-07-14 at 18 15 13" src="https://user-images.githubusercontent.com/20565536/125656322-55cac80b-d538-4ab5-aedf-584680884cae.png">

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- [x] Structural changes reflected in Readme
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [x] Approved by Designer, Engineer, & PO
