### PR TITLE
Update blueDarkText token

### DIFF
--- a/packages/other/tokens/base-tokens.json
+++ b/packages/other/tokens/base-tokens.json
@@ -51,7 +51,7 @@
       "blueLight": "#60E7FF",
       "blue": "#06BDFC",
       "blueDark": "#009BD8",
-      "blueDarkText": "#007BB6",
+      "blueDarkText": "#0075AD",
       "purpleLight": "#974DFF",
       "purple": "#7933FF",
       "purpleDark": "#5646A5",

--- a/packages/other/tokens/test/__snapshots__/newTokens.spec.js.snap
+++ b/packages/other/tokens/test/__snapshots__/newTokens.spec.js.snap
@@ -44,7 +44,7 @@ export const colors = {
   blueLight: '#60E7FF',
   blue: '#06BDFC',
   blueDark: '#009BD8',
-  blueDarkText: '#007BB6',
+  blueDarkText: '#0075AD',
   purpleLight: '#974DFF',
   purple: '#7933FF',
   purpleDark: '#5646A5',

--- a/packages/react-components/form-elements/src/Input/index.tsx
+++ b/packages/react-components/form-elements/src/Input/index.tsx
@@ -202,7 +202,7 @@ const InternalInput = ({
         {({ css: getClassName }) =>
           React.cloneElement(icon, {
             className: getClassName(iconStyle),
-            size: iconSize[size],
+            size: 'medium',
           })
         }
       </ClassNames>

--- a/packages/react-components/text/src/components/__snapshots__/Link.spec.tsx.snap
+++ b/packages/react-components/text/src/components/__snapshots__/Link.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`<Text /> renders with a string 1`] = `
   color: #05192D;
   font-family: Studio-Feixen-Sans,Arial,sans-serif;
   font-style: normal;
-  color: #007BB6;
+  color: #0075AD;
   cursor: pointer;
   font-size: 14px;
   font-weight: 400;

--- a/packages/react-components/text/src/components/__snapshots__/Paragraph.spec.tsx.snap
+++ b/packages/react-components/text/src/components/__snapshots__/Paragraph.spec.tsx.snap
@@ -58,7 +58,7 @@ exports[`<Paragraph /> renders with Strong, Small, Text, Link and Emphasis child
   color: #05192D;
   font-family: Studio-Feixen-Sans,Arial,sans-serif;
   font-style: normal;
-  color: #007BB6;
+  color: #0075AD;
   cursor: pointer;
   font-size: 14px;
   font-weight: 400;


### PR DESCRIPTION
Update **blueDarkText** token to meet a11y criteria for white and light beige backgrounds.