### PR TITLE
Bump react-markdown for beta Markdown component

### DIFF
--- a/packages/react-components/markdown/package.json
+++ b/packages/react-components/markdown/package.json
@@ -55,7 +55,7 @@
     "@babel/runtime": "^7.12.1",
     "@datacamp/waffles-text": "^6.0.0-beta.2",
     "prop-types": "^15.7.2",
-    "react-markdown": "^4.3.1"
+    "react-markdown": "^5.0.3"
   },
   "peerDependencies": {
     "@emotion/react": "^11.0.0",

--- a/packages/react-components/markdown/src/components/Markdown.spec.tsx
+++ b/packages/react-components/markdown/src/components/Markdown.spec.tsx
@@ -1,7 +1,6 @@
 import fs from 'fs';
 
 import { render } from '@testing-library/react';
-import React from 'react';
 
 import Markdown from './Markdown';
 

--- a/packages/react-components/markdown/src/components/Markdown.tsx
+++ b/packages/react-components/markdown/src/components/Markdown.tsx
@@ -5,7 +5,7 @@ import {
   Paragraph,
   Strong,
 } from '@datacamp/waffles-text';
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 interface MarkdownProps {

--- a/packages/react-components/markdown/src/components/__snapshots__/Markdown.spec.tsx.snap
+++ b/packages/react-components/markdown/src/components/__snapshots__/Markdown.spec.tsx.snap
@@ -3,119 +3,139 @@
 exports[`<Markdown /> renders 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
-  color: #05192D;
-  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  color: rgb(5, 25, 45);
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
-  color: #05192D;
+  color: rgb(5, 25, 45);
   font-weight: 800;
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 28px;
-  letter-spacing: 0px;
-  line-height: 1.25;
+  font-size: 40px;
+  letter-spacing: -1px;
+  line-height: 1.2;
 }
 
 *:not(style)~.emotion-0 {
-  margin-top: 16px;
+  margin-top: 24px;
 }
 
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
-  color: #05192D;
-  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  color: rgb(5, 25, 45);
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
-  color: #05192D;
+  color: rgb(5, 25, 45);
+  font-weight: 800;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 32px;
+  letter-spacing: -0.5px;
+  line-height: 1.2;
+}
+
+*:not(style)~.emotion-1 {
+  margin-top: 16px;
+}
+
+.emotion-2 {
+  -webkit-font-smoothing: antialiased;
+  color: rgb(5, 25, 45);
+  font-family: Studio-Feixen-Sans,Arial;
+  font-style: normal;
+  color: rgb(5, 25, 45);
+  font-weight: 800;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 24px;
+  letter-spacing: -0.5px;
+  line-height: 1.2;
+}
+
+*:not(style)~.emotion-2 {
+  margin-top: 16px;
+}
+
+.emotion-3 {
+  -webkit-font-smoothing: antialiased;
+  color: rgb(5, 25, 45);
+  font-family: Studio-Feixen-Sans,Arial;
+  font-style: normal;
+  color: rgb(5, 25, 45);
   font-weight: 800;
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 20px;
-  letter-spacing: 0px;
-  line-height: 1.25;
+  letter-spacing: 0;
+  line-height: 1.2;
 }
 
-*:not(style)~.emotion-1 {
-  margin-top: 8px;
+*:not(style)~.emotion-3 {
+  margin-top: 16px;
 }
 
-.emotion-2 {
+.emotion-4 {
   -webkit-font-smoothing: antialiased;
-  color: #05192D;
-  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  color: rgb(5, 25, 45);
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
-  color: #05192D;
+  color: rgb(5, 25, 45);
+  font-weight: 800;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 18px;
+  letter-spacing: 0;
+  line-height: 1.2;
+}
+
+*:not(style)~.emotion-4 {
+  margin-top: 16px;
+}
+
+.emotion-5 {
+  -webkit-font-smoothing: antialiased;
+  color: rgb(5, 25, 45);
+  font-family: Studio-Feixen-Sans,Arial;
+  font-style: normal;
+  color: rgb(5, 25, 45);
   font-weight: 800;
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 16px;
-  letter-spacing: 0px;
-  line-height: 1.25;
+  letter-spacing: 0;
+  line-height: 1.2;
 }
 
-*:not(style)~.emotion-2 {
-  margin-top: 8px;
-}
-
-.emotion-3 {
-  -webkit-font-smoothing: antialiased;
-  color: #05192D;
-  font-family: Studio-Feixen-Sans,Arial,sans-serif;
-  font-style: normal;
-  color: #05192D;
-  font-weight: 800;
-  margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 14px;
-  letter-spacing: 0px;
-  line-height: 1.25;
-}
-
-*:not(style)~.emotion-3 {
-  margin-top: 8px;
-}
-
-.emotion-4 {
-  -webkit-font-smoothing: antialiased;
-  color: #05192D;
-  font-family: Studio-Feixen-Sans,Arial,sans-serif;
-  font-style: normal;
-  color: #05192D;
-  font-weight: 800;
-  margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 12px;
-  letter-spacing: 0px;
-  line-height: 1.25;
-}
-
-*:not(style)~.emotion-4 {
-  margin-top: 8px;
+*:not(style)~.emotion-5 {
+  margin-top: 16px;
 }
 
 .emotion-7 {
   -webkit-font-smoothing: antialiased;
-  color: #05192D;
-  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  color: rgb(5, 25, 45);
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-weight: 800;
-  line-height: 1.5;
+  line-height: 16px;
 }
 
 .emotion-8 {
   -webkit-font-smoothing: antialiased;
-  color: #05192D;
-  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  color: rgb(5, 25, 45);
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 400;
   line-height: 1.5;
   margin: 0;
@@ -127,18 +147,18 @@ exports[`<Markdown /> renders 1`] = `
 
 .emotion-12 {
   -webkit-font-smoothing: antialiased;
-  color: #05192D;
-  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  color: rgb(5, 25, 45);
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   font-style: italic;
   font-weight: 400;
-  line-height: 14px;
+  line-height: 16px;
 }
 
 .emotion-26 {
   -webkit-font-smoothing: antialiased;
-  color: #05192D;
-  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  color: rgb(5, 25, 45);
+  font-family: Studio-Feixen-Sans,Arial;
   font-style: normal;
   list-style-position: inside;
   margin: 0;
@@ -150,39 +170,46 @@ exports[`<Markdown /> renders 1`] = `
 }
 
 *:not(style)~.emotion-26 {
-  margin-top: 4px;
+  margin-top: 16px;
 }
 
 .emotion-27 {
-  font-size: 14px;
-  line-height: 1.5;
+  line-height: 1.5em;
+  margin-top: 8px;
 }
 
 .emotion-46 {
   border: 0;
   border-radius: 4px;
-  color: #05192D;
-  font-family: JetBrainsMonoNL,Menlo,Monaco,'Courier New',monospace;
-  font-size: 12px;
+  color: rgb(5, 25, 45);
+  font-family: monospace;
+  font-family: JetBrainsMonoNL;
+  font-size: 14px;
   font-variant-ligatures: none;
   letter-spacing: 0;
   line-height: 1.5;
   margin: 0;
   padding: 0;
-  background-color: #EFEBE4;
-  margin: 0 2px;
-  padding: 2px 4px;
-  white-space: nowrap;
+  background-color: rgb(239, 235, 228);
+  margin-left: 2px;
+  margin-right: 4px;
+  padding-bottom: 0;
+  padding-left: 2px;
+  padding-right: 2px;
+  padding-top: 0;
 }
 
 .emotion-47 {
-  background-color: #EFEBE4;
+  background-color: rgb(239, 235, 228);
   border: 0;
   border-radius: 4px;
   line-height: 1.5;
   margin: 0;
   overflow: scroll;
-  padding: 4px 8px;
+  padding-bottom: 8px;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 8px;
 }
 
 *:not(style)~.emotion-47 {
@@ -192,9 +219,10 @@ exports[`<Markdown /> renders 1`] = `
 .emotion-48 {
   border: 0;
   border-radius: 4px;
-  color: #05192D;
-  font-family: JetBrainsMonoNL,Menlo,Monaco,'Courier New',monospace;
-  font-size: 12px;
+  color: rgb(5, 25, 45);
+  font-family: monospace;
+  font-family: JetBrainsMonoNL;
+  font-size: 14px;
   font-variant-ligatures: none;
   letter-spacing: 0;
   line-height: 1.5;
@@ -229,7 +257,7 @@ exports[`<Markdown /> renders 1`] = `
     This is an h5 tag
   </h5>
   <h6
-    class="emotion-4"
+    class="emotion-5"
   >
     This is an h6 tag
   </h6>
@@ -326,11 +354,7 @@ exports[`<Markdown /> renders 1`] = `
   <p
     class="emotion-8"
   >
-    This paragraph has a 
-    <del>
-      strikthrough
-    </del>
-     in it.
+    This paragraph has a ~~strikthrough~~ in it.
   </p>
   <h3
     class="emotion-2"
@@ -450,12 +474,7 @@ exports[`<Markdown /> renders 1`] = `
   <p
     class="emotion-8"
   >
-    <a
-      href="http://github.com"
-    >
-      http://github.com
-    </a>
-     - automatic!
+    http://github.com - automatic!
   </p>
   <p
     class="emotion-8"
@@ -545,17 +564,10 @@ React.render(
     <li
       class="emotion-27"
     >
-      <input
-        aria-labelledby="10val-checkbox-description"
-        checked=""
-        disabled=""
-        readonly=""
-        type="checkbox"
-      />
       <span
         id="10val-checkbox-description"
       >
-        @mentions, #refs, 
+        [x] @mentions, #refs, 
         <a
           href="http://github.com"
         >
@@ -577,81 +589,39 @@ React.render(
     <li
       class="emotion-27"
     >
-      <input
-        aria-labelledby="11val-checkbox-description"
-        checked=""
-        disabled=""
-        readonly=""
-        type="checkbox"
-      />
       <span
         id="11val-checkbox-description"
       >
-        list syntax required (any unordered or ordered list supported)
+        [x] list syntax required (any unordered or ordered list supported)
       </span>
     </li>
     <li
       class="emotion-27"
     >
-      <input
-        aria-labelledby="12val-checkbox-description"
-        checked=""
-        disabled=""
-        readonly=""
-        type="checkbox"
-      />
       <span
         id="12val-checkbox-description"
       >
-        this is a complete item
+        [x] this is a complete item
       </span>
     </li>
     <li
       class="emotion-27"
     >
-      <input
-        aria-labelledby="13val-checkbox-description"
-        disabled=""
-        readonly=""
-        type="checkbox"
-      />
       <span
         id="13val-checkbox-description"
       >
-        this is an incomplete item
+        [ ] this is an incomplete item
       </span>
     </li>
   </ul>
-  <table>
-    <thead>
-      <tr>
-        <th>
-          First Header
-        </th>
-        <th>
-          Second Header
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>
-          Content from cell 1
-        </td>
-        <td>
-          Content from cell 2
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Content in the first column
-        </td>
-        <td>
-          Content in the second column
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <p
+    class="emotion-8"
+  >
+    First Header | Second Header
+------------ | -------------
+Content from cell 1 | Content from cell 2
+Content in the first column | Content in the second column
+  </p>
   &lt;h1&gt;This is an h1&lt;br&gt;with HTML&lt;/h1&gt;
 &lt;table&gt;
   &lt;tr&gt;

--- a/packages/react-components/markdown/src/components/__snapshots__/Markdown.spec.tsx.snap
+++ b/packages/react-components/markdown/src/components/__snapshots__/Markdown.spec.tsx.snap
@@ -3,139 +3,119 @@
 exports[`<Markdown /> renders 1`] = `
 .emotion-0 {
   -webkit-font-smoothing: antialiased;
-  color: rgb(5, 25, 45);
-  font-family: Studio-Feixen-Sans,Arial;
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
   font-style: normal;
-  color: rgb(5, 25, 45);
+  color: #05192D;
   font-weight: 800;
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 40px;
-  letter-spacing: -1px;
-  line-height: 1.2;
+  font-size: 28px;
+  letter-spacing: 0px;
+  line-height: 1.25;
 }
 
 *:not(style)~.emotion-0 {
-  margin-top: 24px;
+  margin-top: 16px;
 }
 
 .emotion-1 {
   -webkit-font-smoothing: antialiased;
-  color: rgb(5, 25, 45);
-  font-family: Studio-Feixen-Sans,Arial;
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
   font-style: normal;
-  color: rgb(5, 25, 45);
-  font-weight: 800;
-  margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 32px;
-  letter-spacing: -0.5px;
-  line-height: 1.2;
-}
-
-*:not(style)~.emotion-1 {
-  margin-top: 16px;
-}
-
-.emotion-2 {
-  -webkit-font-smoothing: antialiased;
-  color: rgb(5, 25, 45);
-  font-family: Studio-Feixen-Sans,Arial;
-  font-style: normal;
-  color: rgb(5, 25, 45);
-  font-weight: 800;
-  margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 24px;
-  letter-spacing: -0.5px;
-  line-height: 1.2;
-}
-
-*:not(style)~.emotion-2 {
-  margin-top: 16px;
-}
-
-.emotion-3 {
-  -webkit-font-smoothing: antialiased;
-  color: rgb(5, 25, 45);
-  font-family: Studio-Feixen-Sans,Arial;
-  font-style: normal;
-  color: rgb(5, 25, 45);
+  color: #05192D;
   font-weight: 800;
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 20px;
-  letter-spacing: 0;
-  line-height: 1.2;
+  letter-spacing: 0px;
+  line-height: 1.25;
+}
+
+*:not(style)~.emotion-1 {
+  margin-top: 8px;
+}
+
+.emotion-2 {
+  -webkit-font-smoothing: antialiased;
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-style: normal;
+  color: #05192D;
+  font-weight: 800;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 16px;
+  letter-spacing: 0px;
+  line-height: 1.25;
+}
+
+*:not(style)~.emotion-2 {
+  margin-top: 8px;
+}
+
+.emotion-3 {
+  -webkit-font-smoothing: antialiased;
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-style: normal;
+  color: #05192D;
+  font-weight: 800;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+  letter-spacing: 0px;
+  line-height: 1.25;
 }
 
 *:not(style)~.emotion-3 {
-  margin-top: 16px;
+  margin-top: 8px;
 }
 
 .emotion-4 {
   -webkit-font-smoothing: antialiased;
-  color: rgb(5, 25, 45);
-  font-family: Studio-Feixen-Sans,Arial;
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
   font-style: normal;
-  color: rgb(5, 25, 45);
+  color: #05192D;
   font-weight: 800;
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 18px;
-  letter-spacing: 0;
-  line-height: 1.2;
+  font-size: 12px;
+  letter-spacing: 0px;
+  line-height: 1.25;
 }
 
 *:not(style)~.emotion-4 {
-  margin-top: 16px;
-}
-
-.emotion-5 {
-  -webkit-font-smoothing: antialiased;
-  color: rgb(5, 25, 45);
-  font-family: Studio-Feixen-Sans,Arial;
-  font-style: normal;
-  color: rgb(5, 25, 45);
-  font-weight: 800;
-  margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 16px;
-  letter-spacing: 0;
-  line-height: 1.2;
-}
-
-*:not(style)~.emotion-5 {
-  margin-top: 16px;
+  margin-top: 8px;
 }
 
 .emotion-7 {
   -webkit-font-smoothing: antialiased;
-  color: rgb(5, 25, 45);
-  font-family: Studio-Feixen-Sans,Arial;
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
   font-style: normal;
   font-weight: 800;
-  line-height: 16px;
+  line-height: 1.5;
 }
 
 .emotion-8 {
   -webkit-font-smoothing: antialiased;
-  color: rgb(5, 25, 45);
-  font-family: Studio-Feixen-Sans,Arial;
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
   font-style: normal;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   line-height: 1.5;
   margin: 0;
@@ -147,18 +127,18 @@ exports[`<Markdown /> renders 1`] = `
 
 .emotion-12 {
   -webkit-font-smoothing: antialiased;
-  color: rgb(5, 25, 45);
-  font-family: Studio-Feixen-Sans,Arial;
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
   font-style: normal;
   font-style: italic;
   font-weight: 400;
-  line-height: 16px;
+  line-height: 14px;
 }
 
 .emotion-26 {
   -webkit-font-smoothing: antialiased;
-  color: rgb(5, 25, 45);
-  font-family: Studio-Feixen-Sans,Arial;
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
   font-style: normal;
   list-style-position: inside;
   margin: 0;
@@ -170,46 +150,39 @@ exports[`<Markdown /> renders 1`] = `
 }
 
 *:not(style)~.emotion-26 {
-  margin-top: 16px;
+  margin-top: 4px;
 }
 
 .emotion-27 {
-  line-height: 1.5em;
-  margin-top: 8px;
+  font-size: 14px;
+  line-height: 1.5;
 }
 
 .emotion-46 {
   border: 0;
   border-radius: 4px;
-  color: rgb(5, 25, 45);
-  font-family: monospace;
-  font-family: JetBrainsMonoNL;
-  font-size: 14px;
+  color: #05192D;
+  font-family: JetBrainsMonoNL,Menlo,Monaco,'Courier New',monospace;
+  font-size: 12px;
   font-variant-ligatures: none;
   letter-spacing: 0;
   line-height: 1.5;
   margin: 0;
   padding: 0;
-  background-color: rgb(239, 235, 228);
-  margin-left: 2px;
-  margin-right: 4px;
-  padding-bottom: 0;
-  padding-left: 2px;
-  padding-right: 2px;
-  padding-top: 0;
+  background-color: #EFEBE4;
+  margin: 0 2px;
+  padding: 2px 4px;
+  white-space: nowrap;
 }
 
 .emotion-47 {
-  background-color: rgb(239, 235, 228);
+  background-color: #EFEBE4;
   border: 0;
   border-radius: 4px;
   line-height: 1.5;
   margin: 0;
   overflow: scroll;
-  padding-bottom: 8px;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 8px;
+  padding: 4px 8px;
 }
 
 *:not(style)~.emotion-47 {
@@ -219,10 +192,9 @@ exports[`<Markdown /> renders 1`] = `
 .emotion-48 {
   border: 0;
   border-radius: 4px;
-  color: rgb(5, 25, 45);
-  font-family: monospace;
-  font-family: JetBrainsMonoNL;
-  font-size: 14px;
+  color: #05192D;
+  font-family: JetBrainsMonoNL,Menlo,Monaco,'Courier New',monospace;
+  font-size: 12px;
   font-variant-ligatures: none;
   letter-spacing: 0;
   line-height: 1.5;
@@ -257,7 +229,7 @@ exports[`<Markdown /> renders 1`] = `
     This is an h5 tag
   </h5>
   <h6
-    class="emotion-5"
+    class="emotion-4"
   >
     This is an h6 tag
   </h6>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5126,6 +5126,13 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/mdast@^3.0.3":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"
+  integrity sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/mdx-js__react@^1.5.3":
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/@types/mdx-js__react/-/mdx-js__react-1.5.3.tgz#2f858ab0ee5fc60b642f3764ef9001fe0530fe43"
@@ -10328,7 +10335,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4.3.2, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@4.3.2, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -10737,12 +10744,13 @@ dom-serializer@0, dom-serializer@~0.1.1:
     domelementtype "^1.3.0"
     entities "^1.1.1"
 
-dom-serializer@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.1.tgz#13650c850daffea35d8b626a4cfc4d3a17643fdb"
-  integrity sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==
+dom-serializer@^1.0.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
+  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
   dependencies:
     domelementtype "^2.0.1"
+    domhandler "^4.2.0"
     entities "^2.0.0"
 
 dom-walk@^0.1.0:
@@ -10765,10 +10773,10 @@ domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
-domelementtype@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
-  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
+domelementtype@^2.0.1, domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
 
 domexception@^2.0.1:
   version "2.0.1"
@@ -10784,12 +10792,19 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domhandler@^3.0, domhandler@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.0.0.tgz#51cd13efca31da95bbb0c5bee3a48300e333b3e9"
-  integrity sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==
+domhandler@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.3.0.tgz#6db7ea46e4617eb15cf875df68b2b8524ce0037a"
+  integrity sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==
   dependencies:
     domelementtype "^2.0.1"
+
+domhandler@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.2.tgz#e825d721d19a86b8c201a35264e226c678ee755f"
+  integrity sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==
+  dependencies:
+    domelementtype "^2.2.0"
 
 domutils@1.5.1:
   version "1.5.1"
@@ -10807,14 +10822,14 @@ domutils@^1.5.1, domutils@^1.7.0:
     dom-serializer "0"
     domelementtype "1"
 
-domutils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.0.0.tgz#15b8278e37bfa8468d157478c58c367718133c08"
-  integrity sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==
+domutils@^2.4.2:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
   dependencies:
-    dom-serializer "^0.2.1"
-    domelementtype "^2.0.1"
-    domhandler "^3.0.0"
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -11113,9 +11128,9 @@ entities@^1.1.1, entities@~1.1.1:
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
 entities@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
-  integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
 env-paths@^1.0.0:
   version "1.0.0"
@@ -13681,14 +13696,14 @@ html-tag-names@1.1.2:
   integrity sha1-9lFolkxanIJnXv2ogoddyyqHXCI=
 
 html-to-react@^1.3.4:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/html-to-react/-/html-to-react-1.4.1.tgz#64f67657c6335056866e334c097556f25894dd47"
-  integrity sha512-Ys2gGxF8LBF9bD8tbnsU0xgEDOTC3Sy81mtpIH/61hSqGE1l4QetnN1yv0oAK/PuvwABmiNS+ggqvuzo+GfoiA==
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/html-to-react/-/html-to-react-1.4.5.tgz#59091c11021d1ef315ef738460abb6a4a41fe1ce"
+  integrity sha512-KONZUDFPg5OodWaQu2ymfkDmU0JA7zB1iPfvyHehTmMUZnk0DS7/TyCMTzsLH6b4BvxX15g88qZCXFhJWktsmA==
   dependencies:
-    domhandler "^3.0"
-    htmlparser2 "^4.0"
+    domhandler "^3.3.0"
+    htmlparser2 "^5.0"
     lodash.camelcase "^4.3.0"
-    ramda "^0.26"
+    ramda "^0.27.1"
 
 html-void-elements@^1.0.0:
   version "1.0.5"
@@ -13736,14 +13751,14 @@ htmlparser2@^3.3.0, htmlparser2@^3.9.1:
     inherits "^2.0.1"
     readable-stream "^3.1.1"
 
-htmlparser2@^4.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.0.0.tgz#6034658db65b7713a572a9ebf79f650832dceec8"
-  integrity sha512-cChwXn5Vam57fyXajDtPXL1wTYc8JtLbr2TN76FYu05itVVVealxLowe2B3IEznJG4p9HAYn/0tJaRlGuEglFQ==
+htmlparser2@^5.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-5.0.1.tgz#7daa6fc3e35d6107ac95a4fc08781f091664f6e7"
+  integrity sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==
   dependencies:
     domelementtype "^2.0.1"
-    domhandler "^3.0.0"
-    domutils "^2.0.0"
+    domhandler "^3.3.0"
+    domutils "^2.4.2"
     entities "^2.0.0"
 
 http-cache-semantics@^3.8.1:
@@ -16524,6 +16539,17 @@ mdast-util-definitions@^4.0.0:
   dependencies:
     unist-util-visit "^2.0.0"
 
+mdast-util-from-markdown@^0.8.0:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
+  integrity sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-string "^2.0.0"
+    micromark "~2.11.0"
+    parse-entities "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
+
 mdast-util-to-hast@10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-10.0.1.tgz#0cfc82089494c52d46eb0e3edb7a4eb2aea021eb"
@@ -16537,6 +16563,11 @@ mdast-util-to-hast@10.0.1:
     unist-util-generated "^1.0.0"
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
+
+mdast-util-to-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
+  integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
 
 mdn-data@2.0.14:
   version "2.0.14"
@@ -16699,6 +16730,14 @@ microevent.ts@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
   integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
+
+micromark@~2.11.0:
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
+  integrity sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==
+  dependencies:
+    debug "^4.0.0"
+    parse-entities "^2.0.0"
 
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
@@ -18298,7 +18337,7 @@ parse-asn1@^5.0.0:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
-parse-entities@^1.1.0, parse-entities@^1.1.2:
+parse-entities@^1.1.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
   integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
@@ -20084,12 +20123,7 @@ ramda@^0.25.0:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
   integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
 
-ramda@^0.26:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
-  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
-
-ramda@~0.27.1:
+ramda@^0.27.1, ramda@~0.27.1:
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
   integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
@@ -20384,18 +20418,20 @@ react-live@^2.2.3:
     react-simple-code-editor "^0.10.0"
     unescape "^1.0.1"
 
-react-markdown@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.3.1.tgz#39f0633b94a027445b86c9811142d05381300f2f"
-  integrity sha512-HQlWFTbDxTtNY6bjgp3C3uv1h2xcjCSi1zAEzfBW9OwJJvENSYiLXWNXN5hHLsoqai7RnZiiHzcnWdXk2Splzw==
+react-markdown@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-5.0.3.tgz#41040ea7a9324b564b328fb81dd6c04f2a5373ac"
+  integrity sha512-jDWOc1AvWn0WahpjW6NK64mtx6cwjM4iSsLHJPNBqoAgGOVoIdJMqaKX4++plhOtdd4JksdqzlDibgPx6B/M2w==
   dependencies:
+    "@types/mdast" "^3.0.3"
+    "@types/unist" "^2.0.3"
     html-to-react "^1.3.4"
     mdast-add-list-metadata "1.0.1"
     prop-types "^15.7.2"
     react-is "^16.8.6"
-    remark-parse "^5.0.0"
-    unified "^6.1.5"
-    unist-util-visit "^1.3.0"
+    remark-parse "^9.0.0"
+    unified "^9.0.0"
+    unist-util-visit "^2.0.0"
     xtend "^4.0.1"
 
 react-merge-refs@^1.1.0:
@@ -21152,26 +21188,12 @@ remark-parse@8.0.3:
     vfile-location "^3.0.0"
     xtend "^4.0.1"
 
-remark-parse@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
-  integrity sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==
+remark-parse@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-9.0.0.tgz#4d20a299665880e4f4af5d90b7c7b8a935853640"
+  integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
   dependencies:
-    collapse-white-space "^1.0.2"
-    is-alphabetical "^1.0.0"
-    is-decimal "^1.0.0"
-    is-whitespace-character "^1.0.0"
-    is-word-character "^1.0.0"
-    markdown-escapes "^1.0.0"
-    parse-entities "^1.1.0"
-    repeat-string "^1.5.4"
-    state-toggle "^1.0.0"
-    trim "0.0.1"
-    trim-trailing-lines "^1.0.0"
-    unherit "^1.0.4"
-    unist-util-remove-position "^1.0.0"
-    vfile-location "^2.0.0"
-    xtend "^4.0.1"
+    mdast-util-from-markdown "^0.8.0"
 
 remark-squeeze-paragraphs@4.0.0:
   version "4.0.0"
@@ -24057,17 +24079,17 @@ unified@9.2.0:
     trough "^1.0.0"
     vfile "^4.0.0"
 
-unified@^6.1.5:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
-  integrity sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==
+unified@^9.0.0:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.2.tgz#67649a1abfc3ab85d2969502902775eb03146975"
+  integrity sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==
   dependencies:
     bail "^1.0.0"
     extend "^3.0.0"
-    is-plain-obj "^1.1.0"
+    is-buffer "^2.0.0"
+    is-plain-obj "^2.0.0"
     trough "^1.0.0"
-    vfile "^2.0.0"
-    x-is-string "^0.1.0"
+    vfile "^4.0.0"
 
 union-value@^1.0.0:
   version "1.0.0"
@@ -24120,11 +24142,6 @@ unist-util-generated@^1.0.0:
   resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.6.tgz#5ab51f689e2992a472beb1b35f2ce7ff2f324d4b"
   integrity sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==
 
-unist-util-is@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
-  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
-
 unist-util-is@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.1.0.tgz#976e5f462a7a5de73d94b706bac1b90671b57797"
@@ -24134,13 +24151,6 @@ unist-util-position@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.1.0.tgz#1c42ee6301f8d52f47d14f62bbdb796571fa2d47"
   integrity sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==
-
-unist-util-remove-position@^1.0.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz#d91aa8b89b30cb38bad2924da11072faa64fd972"
-  integrity sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==
-  dependencies:
-    unist-util-visit "^1.1.0"
 
 unist-util-remove-position@^2.0.0:
   version "2.0.1"
@@ -24173,13 +24183,6 @@ unist-util-visit-parents@1.1.2:
   resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz#f6e3afee8bdbf961c0e6f028ea3c0480028c3d06"
   integrity sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q==
 
-unist-util-visit-parents@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
-  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
-  dependencies:
-    unist-util-is "^3.0.0"
-
 unist-util-visit-parents@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz#65a6ce698f78a6b0f56aa0e88f13801886cdaef6"
@@ -24196,13 +24199,6 @@ unist-util-visit@2.0.3, unist-util-visit@^2.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
-
-unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
-  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
-  dependencies:
-    unist-util-visit-parents "^2.0.0"
 
 universal-user-agent@^3.0.0:
   version "3.0.0"
@@ -24493,11 +24489,6 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
-
-vfile-location@^2.0.0:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.5.tgz#c83eb02f8040228a8d2b3f10e485be3e3433e0a2"
-  integrity sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ==
 
 vfile-location@^3.0.0, vfile-location@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
## Proposed changes

Bumped **react-markdown** version to **5.0.3** so it works with newer version of Webpack.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- ~[ ] Technical docs written~
- ~[ ] Structural changes reflected in Readme~
- ~[ ] Migration plan for breaking changes~

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- ~[ ] Approved by Designer, Engineer, & PO~
