### PR TITLE
[WF-528] New design tokens as Sass variables

### DIFF
--- a/packages/other/tokens/buildNewTokens.js
+++ b/packages/other/tokens/buildNewTokens.js
@@ -1,161 +1,25 @@
-// Generate new design tokens JS file based on JSON file with Figma Tokens definitions
-// It will be used to generate both ESM and CJS modules, and TS typings
-
-// fontWeights, fontFamilies, and boxShadow have non-standard values to work with Figma Tokens
-// typography and paragraphSpacing are defined for convenience  and are removed
-// colors are grouped for convenience and are flattened
+// Generate new design tokens JS and SCSS files based on JSON file with Figma Tokens definitions
 
 const fs = require('fs');
-const util = require('util');
+
+const { tokensToEsModule } = require('./newTokensHelpers/tokensToEsModule');
+const {
+  tokensToSassVariables,
+} = require('./newTokensHelpers/tokensToSassVariables');
+const {
+  transformedBaseTokens,
+} = require('./newTokensHelpers/transformedBaseTokens');
 
 const baseTokens = require('./base-tokens.json'); // Already parsed to JS
 
-// Mappign for Figma Tokens values and CSS couterparts
-
-const fontWeights = {
-  Bold: 800,
-  Regular: 400,
-};
-
-const fontFamilies = {
-  'JetBrains Mono NL':
-    "JetBrainsMonoNL, Menlo, Monaco, 'Courier New', monospace",
-  'Studio Feixen Sans': 'Studio-Feixen-Sans, Arial, sans-serif',
-};
-
-// Transformations for colors, boxShadow, fontWeights, fontFamilies, and lineHeights
-
-function transformedColors(baseColors) {
-  return Object.entries(baseColors).reduce((flattenedColors, currentEntry) => {
-    const groupedColors = currentEntry[1];
-    return Object.assign(flattenedColors, { ...groupedColors });
-  }, {});
-}
-
-function transformedBoxShadows(baseBoxShadows) {
-  return Object.fromEntries(
-    Object.entries(baseBoxShadows).map((entry) => {
-      const [key, baseBoxShadow] = entry;
-      const { blur, color, spread, x, y } = baseBoxShadow.value;
-      // Regular CSS box-shadow value
-      const regularBoxShadow = `${x} ${y} ${blur} ${spread} ${color}`;
-
-      return [key, regularBoxShadow];
-    }),
-  );
-}
-
-function transformedFontWeights(baseFontWeights) {
-  return Object.fromEntries(
-    Object.entries(baseFontWeights).map((entry) => {
-      const [key, baseFontWeight] = entry;
-      return [key, fontWeights[baseFontWeight]];
-    }),
-  );
-}
-
-function transformedFontFamilies(baseFontFamilies) {
-  return Object.fromEntries(
-    Object.entries(baseFontFamilies).map((entry) => {
-      const [key, baseFontFamily] = entry;
-      return [key, fontFamilies[baseFontFamily]];
-    }),
-  );
-}
-
-function transformedLineHeights(baseLineHeights) {
-  return Object.fromEntries(
-    Object.entries(baseLineHeights).map((entry) => {
-      const [key, baseLineHeight] = entry;
-      // Because percanteges are really quirky in CSS, convert them to unitless
-      const regularLineHeight = parseFloat(baseLineHeight) / 100;
-      return [key, regularLineHeight];
-    }),
-  );
-}
-
-// Apply trasformations and remove typography and paragraphSpacing sections
-function transformedBaseTokens(tokens) {
-  const transformedTokens = {
-    ...tokens,
-    boxShadow: {
-      ...transformedBoxShadows(tokens.boxShadow),
-    },
-    colors: {
-      ...transformedColors(tokens.colors),
-    },
-    fontFamilies: {
-      ...transformedFontFamilies(tokens.fontFamilies),
-    },
-    fontWeights: {
-      ...transformedFontWeights(tokens.fontWeights),
-    },
-    lineHeights: {
-      ...transformedLineHeights(tokens.lineHeights),
-    },
-  };
-
-  delete transformedTokens.typography;
-  delete transformedTokens.paragraphSpacing;
-
-  return transformedTokens;
-}
-
-// Create separate export for each token group (like colors, lineHeights, etc.)
-function exportForEachTokenGroup(tokens) {
-  let exports = '';
-  Object.entries(tokens).forEach((entry) => {
-    const [key, tokenGroupValues] = entry;
-    // Stringify values in a token group
-    const stringifiedValues = util.inspect(tokenGroupValues, { depth: null });
-    exports += `export const ${key} = ${stringifiedValues};\n`;
-  });
-
-  return exports;
-}
-
-// To make it more ergonomic create default export
-function tokensDefaultExport(tokens) {
-  // Comma separated list of exports
-  let groupsToExport = '';
-  const tokensKeys = Object.keys(tokens);
-
-  tokensKeys.forEach((key, index) => {
-    let separator = '';
-    if (index < tokensKeys.length - 1) {
-      separator = ', ';
-    }
-    groupsToExport += `${key}${separator}`;
-  });
-
-  return `export default { ${groupsToExport} };`;
-}
-
-// Content of ES modules, later written to file
-// Serves as a base for generating ESM and CJS modules with Babel
-function tokensToEsModule(tokens) {
-  let moduleContent = exportForEachTokenGroup(tokens);
-  moduleContent += tokensDefaultExport(tokens);
-
-  return moduleContent;
-}
-
-const newTokens = tokensToEsModule(transformedBaseTokens(baseTokens));
+const transformedTokens = transformedBaseTokens(baseTokens);
 
 if (!fs.existsSync('./lib')) {
   fs.mkdirSync('./lib');
 }
-fs.writeFileSync('./lib/tokens.js', newTokens);
 
-// Exporting utils for unit tests
-module.exports = {
-  exportForEachTokenGroup,
-  tokensDefaultExport,
-  tokensToEsModule,
-  transformedBaseTokens,
-  transformedBoxShadows,
-  transformedColors,
-  transformedFontFamilies,
-  transformedFontWeights,
-  transformedLineHeights,
-};
+fs.writeFileSync('./lib/tokens.js', tokensToEsModule(transformedTokens));
+fs.writeFileSync(
+  './lib/future-variables.scss',
+  tokensToSassVariables(transformedTokens),
+);

--- a/packages/other/tokens/newTokensHelpers/tokensToEsModule.js
+++ b/packages/other/tokens/newTokensHelpers/tokensToEsModule.js
@@ -1,0 +1,49 @@
+// Transform design tokens to the content of ES module file
+
+const util = require('util');
+
+// Create separate export for each token group (like colors, lineHeights, etc.)
+function exportForEachTokenGroup(tokens) {
+  let exports = '';
+  Object.entries(tokens).forEach((entry) => {
+    const [key, tokenGroupValues] = entry;
+    // Stringify values in a token group
+    const stringifiedValues = util.inspect(tokenGroupValues, { depth: null });
+    exports += `export const ${key} = ${stringifiedValues};\n`;
+  });
+
+  return exports;
+}
+
+// To make it more ergonomic create default export
+function tokensDefaultExport(tokens) {
+  // Comma separated list of exports
+  let groupsToExport = '';
+  const tokensKeys = Object.keys(tokens);
+
+  tokensKeys.forEach((key, index) => {
+    let separator = '';
+    if (index < tokensKeys.length - 1) {
+      separator = ', ';
+    }
+    groupsToExport += `${key}${separator}`;
+  });
+
+  return `export default { ${groupsToExport} };`;
+}
+
+// Content of ES modules, later written to file
+// Serves as a base for generating ESM, and CJS modules with Babel, and TS typings
+function tokensToEsModule(tokens) {
+  let content = exportForEachTokenGroup(tokens);
+  content += tokensDefaultExport(tokens);
+
+  return content;
+}
+
+// Exporting utils for unit tests
+module.exports = {
+  exportForEachTokenGroup,
+  tokensDefaultExport,
+  tokensToEsModule,
+};

--- a/packages/other/tokens/newTokensHelpers/tokensToSassVariables.js
+++ b/packages/other/tokens/newTokensHelpers/tokensToSassVariables.js
@@ -1,0 +1,52 @@
+// Transform design tokens to the content of SCSS variables file
+
+function camelToKebabCase(string) {
+  return string.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+// For consistency, transform new tokens group names to the ones from legacy SCSS variables file
+function legacyTokenGroupName(tokenGroupName) {
+  switch (tokenGroupName) {
+    case 'fontWeights':
+      return 'fontWeight';
+    case 'fontFamilies':
+      return 'fontFamily';
+    case 'fontSizes':
+      return 'fontSize';
+    case 'lineHeights':
+      return 'lineHeight';
+    case 'breakpoints':
+      return 'bp';
+    case 'colors':
+      return '';
+    default:
+      return tokenGroupName;
+  }
+}
+
+// Sass varaibles, later written to SCSS file
+// All namespaced with "dc"
+function tokensToSassVariables(tokens) {
+  let content = '';
+
+  Object.entries(tokens).forEach((groupEentry) => {
+    const [groupName, tokenGroupValues] = groupEentry;
+    const legacyName = legacyTokenGroupName(groupName);
+
+    Object.entries(tokenGroupValues).forEach((tokenEntry) => {
+      const [tokenName, tokenValue] = tokenEntry;
+      content += `$dc-${camelToKebabCase(legacyName)}${
+        legacyName && '-'
+      }${camelToKebabCase(tokenName)}: ${tokenValue};\n`;
+    });
+  });
+
+  return content;
+}
+
+// Exporting utils for unit tests
+module.exports = {
+  camelToKebabCase,
+  legacyTokenGroupName,
+  tokensToSassVariables,
+};

--- a/packages/other/tokens/newTokensHelpers/transformedBaseTokens.js
+++ b/packages/other/tokens/newTokensHelpers/transformedBaseTokens.js
@@ -103,6 +103,7 @@ module.exports = {
   transformedBaseTokens,
   transformedBoxShadows,
   transformedColors,
+  transformedFontFamilies,
   transformedFontWeights,
   transformedPercentages,
 };

--- a/packages/other/tokens/newTokensHelpers/transformedBaseTokens.js
+++ b/packages/other/tokens/newTokensHelpers/transformedBaseTokens.js
@@ -1,0 +1,108 @@
+// Transform Figma Tokens design tokens to CSS compatible values
+// fontWeights, fontFamilies, and boxShadow have non-standard values and are converted
+// typography and paragraphSpacing are removed
+// colors are flattened
+
+// Mappigns between Figma Tokens values and CSS couterparts
+
+const fontWeights = {
+  Bold: 800,
+  Regular: 400,
+};
+
+const fontFamilies = {
+  'JetBrains Mono NL':
+    "JetBrainsMonoNL, Menlo, Monaco, 'Courier New', monospace",
+  'Studio Feixen Sans': 'Studio-Feixen-Sans, Arial, sans-serif',
+};
+
+// Transformations for colors, boxShadow, fontWeights, fontFamilies, lineHeights, and opacity
+
+function transformedColors(baseColors) {
+  return Object.entries(baseColors).reduce((flattenedColors, currentEntry) => {
+    const groupedColors = currentEntry[1];
+    return Object.assign(flattenedColors, { ...groupedColors });
+  }, {});
+}
+
+function transformedBoxShadows(baseBoxShadows) {
+  return Object.fromEntries(
+    Object.entries(baseBoxShadows).map((entry) => {
+      const [key, baseBoxShadow] = entry;
+      const { blur, color, spread, x, y } = baseBoxShadow.value;
+      // Regular CSS box-shadow value
+      const regularBoxShadow = `${x} ${y} ${blur} ${spread} ${color}`;
+
+      return [key, regularBoxShadow];
+    }),
+  );
+}
+
+function transformedFontWeights(baseFontWeights) {
+  return Object.fromEntries(
+    Object.entries(baseFontWeights).map((entry) => {
+      const [key, baseFontWeight] = entry;
+      return [key, fontWeights[baseFontWeight]];
+    }),
+  );
+}
+
+function transformedFontFamilies(baseFontFamilies) {
+  return Object.fromEntries(
+    Object.entries(baseFontFamilies).map((entry) => {
+      const [key, baseFontFamily] = entry;
+      return [key, fontFamilies[baseFontFamily]];
+    }),
+  );
+}
+
+function transformedPercentages(basePercentages) {
+  return Object.fromEntries(
+    Object.entries(basePercentages).map((entry) => {
+      const [key, basePercantege] = entry;
+      // Convert percentages to unitless
+      // Useful for line heights and opacity
+      const unitless = parseFloat(basePercantege) / 100;
+      return [key, unitless];
+    }),
+  );
+}
+
+// Apply trasformations and remove typography and paragraphSpacing sections
+function transformedBaseTokens(tokens) {
+  const transformedTokens = {
+    ...tokens,
+    boxShadow: {
+      ...transformedBoxShadows(tokens.boxShadow),
+    },
+    colors: {
+      ...transformedColors(tokens.colors),
+    },
+    fontFamilies: {
+      ...transformedFontFamilies(tokens.fontFamilies),
+    },
+    fontWeights: {
+      ...transformedFontWeights(tokens.fontWeights),
+    },
+    lineHeights: {
+      ...transformedPercentages(tokens.lineHeights),
+    },
+    opacity: {
+      ...transformedPercentages(tokens.opacity),
+    },
+  };
+
+  delete transformedTokens.typography;
+  delete transformedTokens.paragraphSpacing;
+
+  return transformedTokens;
+}
+
+// Exporting utils for unit tests
+module.exports = {
+  transformedBaseTokens,
+  transformedBoxShadows,
+  transformedColors,
+  transformedFontWeights,
+  transformedPercentages,
+};

--- a/packages/other/tokens/test/__snapshots__/newTokens.spec.js.snap
+++ b/packages/other/tokens/test/__snapshots__/newTokens.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`new tokens base tokens are properly transformed 1`] = `
+exports[`newTokensHelpers base tokens are properly transformed 1`] = `
 "export const sizing = { small: '24px', medium: '36px', large: '48px' };
 export const spacing = {
   xsmall: '4px',
@@ -81,7 +81,7 @@ export const fontSizes = {
 };
 export const letterSpacing = { tight: '-0.5px', default: '0px', relaxed: '1.5px' };
 export const lineHeights = { tight: 1, default: 1.25, relaxed: 1.5 };
-export const opacity = { low: '15%', medium: '40%', high: '60%' };
+export const opacity = { low: 0.15, medium: 0.4, high: 0.6 };
 export const zIndex = {
   default: 1,
   sticky: 100,

--- a/packages/other/tokens/test/newTokens.spec.js
+++ b/packages/other/tokens/test/newTokens.spec.js
@@ -11,6 +11,11 @@ const {
   tokensDefaultExport,
   tokensToEsModule,
 } = require('../newTokensHelpers/tokensToEsModule');
+const {
+  camelToKebabCase,
+  legacyTokenGroupName,
+  tokensToSassVariables,
+} = require('../newTokensHelpers/tokensToSassVariables');
 
 const baseTokens = require('../base-tokens.json');
 
@@ -61,7 +66,7 @@ const testTokens = {
     tight: '100%',
   },
   opacity: {
-    height: '60%',
+    high: '60%',
     low: '15%',
   },
   spacing: {
@@ -96,7 +101,7 @@ const transformedTestTokens = {
     tight: 1,
   },
   opacity: {
-    height: 0.6,
+    high: 0.6,
     low: 0.15,
   },
   spacing: {
@@ -165,7 +170,7 @@ export const fontFamilies = {
 };
 export const fontWeights = { bold: 800, regular: 400 };
 export const lineHeights = { relaxed: 1.5, tight: 1 };
-export const opacity = { height: 0.6, low: 0.15 };
+export const opacity = { high: 0.6, low: 0.15 };
 export const spacing = { large: '24px', medium: '16px', small: '8px' };
 `;
 
@@ -199,11 +204,55 @@ export const fontFamilies = {
 };
 export const fontWeights = { bold: 800, regular: 400 };
 export const lineHeights = { relaxed: 1.5, tight: 1 };
-export const opacity = { height: 0.6, low: 0.15 };
+export const opacity = { high: 0.6, low: 0.15 };
 export const spacing = { large: '24px', medium: '16px', small: '8px' };
 export default { boxShadow, colors, fontFamilies, fontWeights, lineHeights, opacity, spacing };`;
 
       expect(tokensToEsModule(transformedTestTokens)).toEqual(expectedContent);
+    });
+  });
+
+  describe('tokensToSassVariables', () => {
+    it('camelToKebabCase() transforms camel case string to kebab case one', () => {
+      expect(camelToKebabCase('quiteLongCamelCaseName')).toBe(
+        'quite-long-camel-case-name',
+      );
+      expect(camelToKebabCase('name')).toBe('name');
+    });
+
+    it('legacyTokenGroupName() transform new design tokens group name to the legacy one', () => {
+      expect(legacyTokenGroupName('fontWeights')).toBe('fontWeight');
+      expect(legacyTokenGroupName('fontFamilies')).toBe('fontFamily');
+      expect(legacyTokenGroupName('fontFamilies')).toBe('fontFamily');
+      expect(legacyTokenGroupName('breakpoints')).toBe('bp');
+      expect(legacyTokenGroupName('sizing')).toBe('sizing');
+    });
+
+    it('legacyTokenGroupName() transforms "colors" group name to empty string', () => {
+      expect(legacyTokenGroupName('colors')).toBe('');
+    });
+
+    it('tokensToSassVariables() generates content of SCSS file based on provided design tokens', () => {
+      expect(tokensToSassVariables(transformedTestTokens))
+        .toEqual(`$dc-box-shadow-medium: 0px 1px 4px -1px rgba(5, 25, 45, 0.3);
+$dc-box-shadow-thin: 0px 0px 2px 0px rgba(5, 25, 45, 0.3);
+$dc-green: #03EF62;
+$dc-grey: #E8E8EA;
+$dc-navy: #05192D;
+$dc-red-light: #FF782D;
+$dc-white: #FFFFFF;
+$dc-font-family-mono: JetBrainsMonoNL, Menlo, Monaco, 'Courier New', monospace;
+$dc-font-family-sans-serif: Studio-Feixen-Sans, Arial, sans-serif;
+$dc-font-weight-bold: 800;
+$dc-font-weight-regular: 400;
+$dc-line-height-relaxed: 1.5;
+$dc-line-height-tight: 1;
+$dc-opacity-high: 0.6;
+$dc-opacity-low: 0.15;
+$dc-spacing-large: 24px;
+$dc-spacing-medium: 16px;
+$dc-spacing-small: 8px;
+`);
     });
   });
 

--- a/packages/other/tokens/test/newTokens.spec.js
+++ b/packages/other/tokens/test/newTokens.spec.js
@@ -1,14 +1,17 @@
 const {
-  exportForEachTokenGroup,
-  tokensDefaultExport,
-  tokensToEsModule,
   transformedBaseTokens,
   transformedBoxShadows,
   transformedColors,
   transformedFontFamilies,
   transformedFontWeights,
-  transformedLineHeights,
-} = require('../buildNewTokens');
+  transformedPercentages,
+} = require('../newTokensHelpers/transformedBaseTokens');
+const {
+  exportForEachTokenGroup,
+  tokensDefaultExport,
+  tokensToEsModule,
+} = require('../newTokensHelpers/tokensToEsModule');
+
 const baseTokens = require('../base-tokens.json');
 
 const testTokens = {
@@ -57,6 +60,10 @@ const testTokens = {
     relaxed: '150%',
     tight: '100%',
   },
+  opacity: {
+    height: '60%',
+    low: '15%',
+  },
   spacing: {
     large: '24px',
     medium: '16px',
@@ -88,6 +95,10 @@ const transformedTestTokens = {
     relaxed: 1.5,
     tight: 1,
   },
+  opacity: {
+    height: 0.6,
+    low: 0.15,
+  },
   spacing: {
     large: '24px',
     medium: '16px',
@@ -95,43 +106,49 @@ const transformedTestTokens = {
   },
 };
 
-describe('new tokens', () => {
-  it('transformedColors() flattens grouped colors', () => {
-    expect(transformedColors(testTokens.colors)).toEqual(
-      transformedTestTokens.colors,
-    );
+describe('newTokensHelpers', () => {
+  describe('transformedBaseTokens', () => {
+    it('transformedColors() flattens grouped colors', () => {
+      expect(transformedColors(testTokens.colors)).toEqual(
+        transformedTestTokens.colors,
+      );
+    });
+
+    it('transformedBoxShadows() transfroms box shadow from Figma Plugin format to CSS values', () => {
+      expect(transformedBoxShadows(testTokens.boxShadow)).toEqual(
+        transformedTestTokens.boxShadow,
+      );
+    });
+
+    it('transformedFontFamilies() transfroms font families from Figma Plugin format to CSS values', () => {
+      expect(transformedFontFamilies(testTokens.fontFamilies)).toEqual(
+        transformedTestTokens.fontFamilies,
+      );
+    });
+
+    it('transformedFontWeights() transfroms font weights from Figma Plugin format to CSS values', () => {
+      expect(transformedFontWeights(testTokens.fontWeights)).toEqual(
+        transformedTestTokens.fontWeights,
+      );
+    });
+
+    it('transformedPercentages() transfroms line heights and opacity from percanteges to unitless', () => {
+      expect(transformedPercentages(testTokens.lineHeights)).toEqual(
+        transformedTestTokens.lineHeights,
+      );
+      expect(transformedPercentages(testTokens.opacity)).toEqual(
+        transformedTestTokens.opacity,
+      );
+    });
+
+    it('transformedBaseTokens() updates original values to transformed ones', () => {
+      expect(transformedBaseTokens(testTokens)).toEqual(transformedTestTokens);
+    });
   });
 
-  it('transformedBoxShadows() transfroms box shadow from Figma Plugin format to CSS values', () => {
-    expect(transformedBoxShadows(testTokens.boxShadow)).toEqual(
-      transformedTestTokens.boxShadow,
-    );
-  });
-
-  it('transformedFontFamilies() transfroms font families from Figma Plugin format to CSS values', () => {
-    expect(transformedFontFamilies(testTokens.fontFamilies)).toEqual(
-      transformedTestTokens.fontFamilies,
-    );
-  });
-
-  it('transformedFontWeights() transfroms font weights from Figma Plugin format to CSS values', () => {
-    expect(transformedFontWeights(testTokens.fontWeights)).toEqual(
-      transformedTestTokens.fontWeights,
-    );
-  });
-
-  it('transformedLineHeights() transfroms line heights from percanteges to unitless', () => {
-    expect(transformedLineHeights(testTokens.lineHeights)).toEqual(
-      transformedTestTokens.lineHeights,
-    );
-  });
-
-  it('transformedBaseTokens() replaces boxShadow group with transformed one', () => {
-    expect(transformedBaseTokens(testTokens)).toEqual(transformedTestTokens);
-  });
-
-  it('exportForEachTokenGroup() creates ES module export for each token group', () => {
-    const expectedContent = `export const boxShadow = {
+  describe('tokensToEsModule', () => {
+    it('exportForEachTokenGroup() creates ES module export for each token group', () => {
+      const expectedContent = `export const boxShadow = {
   medium: '0px 1px 4px -1px rgba(5, 25, 45, 0.3)',
   thin: '0px 0px 2px 0px rgba(5, 25, 45, 0.3)'
 };
@@ -148,21 +165,24 @@ export const fontFamilies = {
 };
 export const fontWeights = { bold: 800, regular: 400 };
 export const lineHeights = { relaxed: 1.5, tight: 1 };
+export const opacity = { height: 0.6, low: 0.15 };
 export const spacing = { large: '24px', medium: '16px', small: '8px' };
 `;
 
-    expect(exportForEachTokenGroup(transformedTestTokens)).toEqual(
-      expectedContent,
-    );
-  });
+      expect(exportForEachTokenGroup(transformedTestTokens)).toEqual(
+        expectedContent,
+      );
+    });
 
-  it('tokensDefaultExport() creates ES module default export', () => {
-    const expectedContent = `export default { boxShadow, colors, fontFamilies, fontWeights, lineHeights, spacing };`;
-    expect(tokensDefaultExport(transformedTestTokens)).toEqual(expectedContent);
-  });
+    it('tokensDefaultExport() creates ES module default export', () => {
+      const expectedContent = `export default { boxShadow, colors, fontFamilies, fontWeights, lineHeights, opacity, spacing };`;
+      expect(tokensDefaultExport(transformedTestTokens)).toEqual(
+        expectedContent,
+      );
+    });
 
-  it('tokensToEsModule() creates ES module content', () => {
-    const expectedContent = `export const boxShadow = {
+    it('tokensToEsModule() creates ES module content', () => {
+      const expectedContent = `export const boxShadow = {
   medium: '0px 1px 4px -1px rgba(5, 25, 45, 0.3)',
   thin: '0px 0px 2px 0px rgba(5, 25, 45, 0.3)'
 };
@@ -179,10 +199,12 @@ export const fontFamilies = {
 };
 export const fontWeights = { bold: 800, regular: 400 };
 export const lineHeights = { relaxed: 1.5, tight: 1 };
+export const opacity = { height: 0.6, low: 0.15 };
 export const spacing = { large: '24px', medium: '16px', small: '8px' };
-export default { boxShadow, colors, fontFamilies, fontWeights, lineHeights, spacing };`;
+export default { boxShadow, colors, fontFamilies, fontWeights, lineHeights, opacity, spacing };`;
 
-    expect(tokensToEsModule(transformedTestTokens)).toEqual(expectedContent);
+      expect(tokensToEsModule(transformedTestTokens)).toEqual(expectedContent);
+    });
   });
 
   it('base tokens are properly transformed', () => {

--- a/packages/react-components/button/src/UserAccountMenu/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/button/src/UserAccountMenu/__snapshots__/index.spec.tsx.snap
@@ -177,7 +177,7 @@ exports[`UserAccountMenu snapshots renders correctly when all optional props are
   font-size: 14px;
   font-weight: 400;
   height: 42px;
-  opacity: 60%;
+  opacity: 0.6;
   outline: 0;
   padding-left: 24px;
   padding-right: 24px;
@@ -683,7 +683,7 @@ exports[`UserAccountMenu snapshots renders correctly when only main app URL is p
   font-size: 14px;
   font-weight: 400;
   height: 42px;
-  opacity: 60%;
+  opacity: 0.6;
   outline: 0;
   padding-left: 24px;
   padding-right: 24px;

--- a/packages/react-components/form-elements/src/Switch/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/form-elements/src/Switch/__snapshots__/index.spec.tsx.snap
@@ -485,7 +485,7 @@ exports[`snapshots renders a switch with appearance default, disabled=true, chec
   display: inline-flex;
   width: auto;
   cursor: default;
-  opacity: 40%;
+  opacity: 0.4;
 }
 
 .emotion-1 {
@@ -603,7 +603,7 @@ exports[`snapshots renders a switch with appearance default, disabled=true, chec
   display: flex;
   width: 100%;
   cursor: default;
-  opacity: 40%;
+  opacity: 0.4;
 }
 
 .emotion-1 {
@@ -721,7 +721,7 @@ exports[`snapshots renders a switch with appearance default, disabled=true, chec
   display: inline-flex;
   width: auto;
   cursor: default;
-  opacity: 40%;
+  opacity: 0.4;
 }
 
 .emotion-1 {
@@ -839,7 +839,7 @@ exports[`snapshots renders a switch with appearance default, disabled=true, chec
   display: flex;
   width: 100%;
   cursor: default;
-  opacity: 40%;
+  opacity: 0.4;
 }
 
 .emotion-1 {
@@ -1417,7 +1417,7 @@ exports[`snapshots renders a switch with appearance inverted, disabled=true, che
   display: inline-flex;
   width: auto;
   cursor: default;
-  opacity: 40%;
+  opacity: 0.4;
 }
 
 .emotion-1 {
@@ -1535,7 +1535,7 @@ exports[`snapshots renders a switch with appearance inverted, disabled=true, che
   display: flex;
   width: 100%;
   cursor: default;
-  opacity: 40%;
+  opacity: 0.4;
 }
 
 .emotion-1 {
@@ -1653,7 +1653,7 @@ exports[`snapshots renders a switch with appearance inverted, disabled=true, che
   display: inline-flex;
   width: auto;
   cursor: default;
-  opacity: 40%;
+  opacity: 0.4;
 }
 
 .emotion-1 {
@@ -1771,7 +1771,7 @@ exports[`snapshots renders a switch with appearance inverted, disabled=true, che
   display: flex;
   width: 100%;
   cursor: default;
-  opacity: 40%;
+  opacity: 0.4;
 }
 
 .emotion-1 {


### PR DESCRIPTION
# [WF-528](https://datacamp.atlassian.net/browse/WF-528)

## Proposed changes
Parsed new design tokens to Sass variables, which will be exposed in `future-variables.scss` file in `@datacamp/waffles-tokens` package. Migration guide, although for JS file, is available [here](https://waffles.datacamp-staging.com/components/tokens/#migration-guide).
Content of the file (output of _buildNewTokens_ script):
```
$dc-sizing-small: 24px;
$dc-sizing-medium: 36px;
$dc-sizing-large: 48px;
$dc-spacing-xsmall: 4px;
$dc-spacing-small: 8px;
$dc-spacing-medium: 16px;
$dc-spacing-large: 24px;
$dc-spacing-xlarge: 32px;
$dc-navy-light: #213147;
$dc-navy: #05192D;
$dc-navy-dark: #000820;
$dc-navy-subtle-text-on-dark: #9BA3AB;
$dc-navy-subtle-text-on-light: #65707C;
$dc-green-light: #65FF8F;
$dc-green: #03EF62;
$dc-green-dark: #00C53B;
$dc-green-dark-text: #008700;
$dc-white: #FFFFFF;
$dc-grey-subtle: #F7F7FC;
$dc-grey-light: #EFEFEF;
$dc-grey: #E8E8EA;
$dc-grey-medium: #D9D9E2;
$dc-grey-dark: #848C92;
$dc-beige-subtle: #FFFBF3;
$dc-beige-light: #F7F3EB;
$dc-beige: #EFEBE4;
$dc-beige-medium: #E5E1DA;
$dc-red-light: #FF782D;
$dc-red: #FF5400;
$dc-red-dark: #DD3400;
$dc-red-dark-text: #C01100;
$dc-orange-light: #FFBC4B;
$dc-orange: #FF931E;
$dc-orange-dark: #D87300;
$dc-orange-dark-text: #B75900;
$dc-yellow-light: #FFEC3C;
$dc-yellow: #FCCE0D;
$dc-yellow-dark: #CFA600;
$dc-yellow-dark-text: #907000;
$dc-blue-light: #60E7FF;
$dc-blue: #06BDFC;
$dc-blue-dark: #009BD8;
$dc-blue-dark-text: #0075AD;
$dc-purple-light: #974DFF;
$dc-purple: #7933FF;
$dc-purple-dark: #5646A5;
$dc-purple-dark-text: #5646A5;
$dc-pink-light: #FF95CF;
$dc-pink: #FF6EA9;
$dc-pink-dark: #DC4D8B;
$dc-pink-dark-text: #BF3072;
$dc-brand-facebook: #1778F2;
$dc-brand-twitter: #00ACEE;
$dc-brand-google: #DB4437;
$dc-brand-linked-in: #0E76A8;
$dc-border-radius-medium: 4px;
$dc-border-radius-circle: 50%;
$dc-border-width-thin: 1px;
$dc-border-width-medium: 2px;
$dc-border-width-thick: 3px;
$dc-border-width-xthick: 4px;
$dc-box-shadow-thin: 0px 0px 2px 0px rgba(5, 25, 45, 0.3);
$dc-box-shadow-medium: 0px 1px 4px -1px rgba(5, 25, 45, 0.3);
$dc-box-shadow-thick: 0px 3px 5px -1px rgba(5, 25, 45, 0.3);
$dc-box-shadow-xthick: 0px 8px 12px -4px rgba(5, 25, 45, 0.3);
$dc-font-weight-regular: 400;
$dc-font-weight-bold: 800;
$dc-font-family-sans-serif: Studio-Feixen-Sans, Arial, sans-serif;
$dc-font-family-mono: JetBrainsMonoNL, Menlo, Monaco, 'Courier New', monospace;
$dc-font-size-small: 12px;
$dc-font-size-medium: 14px;
$dc-font-size-large: 16px;
$dc-font-size-xlarge: 18px;
$dc-font-size-xxlarge: 20px;
$dc-font-size-huge: 28px;
$dc-letter-spacing-tight: -0.5px;
$dc-letter-spacing-default: 0px;
$dc-letter-spacing-relaxed: 1.5px;
$dc-line-height-tight: 1;
$dc-line-height-default: 1.25;
$dc-line-height-relaxed: 1.5;
$dc-opacity-low: 0.15;
$dc-opacity-medium: 0.4;
$dc-opacity-high: 0.6;
$dc-z-index-default: 1;
$dc-z-index-sticky: 100;
$dc-z-index-dropdown: 7000;
$dc-z-index-overlay: 8000;
$dc-z-index-modal: 9000;
$dc-z-index-toast: 10000;
$dc-bp-small: 480px;
$dc-bp-medium: 820px;
$dc-bp-large: 1480px;
```

In the 'old' variables file there is some kind of colors map:
```
$dc-colors: (
  'blue': $dc-blue,
  'blue-dark': $dc-blue-dark,
  'blue-light': $dc-blue-light,
  ...
}
```
Should it be exposed here as well?
I can also attach the content of 'old' file too for comparison.
 
## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- ~[ ] Technical docs written~
- ~[ ] Structural changes reflected in Readme~
- [x] Migration plan for breaking changes

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [x] Approved by Designer, Engineer, & PO
