### PR TITLE
[WF-559] Auto-grow TextArea

### DIFF
--- a/packages/docs/next-doc-site/examples/form-elements/auto-grow-textarea.tsx
+++ b/packages/docs/next-doc-site/examples/form-elements/auto-grow-textarea.tsx
@@ -1,0 +1,21 @@
+import { TextArea } from '@datacamp/waffles-form-elements';
+import { useState } from 'react';
+
+function Example(): JSX.Element {
+  const [message, setMessage] = useState('');
+
+  return (
+    <form>
+      <TextArea
+        autoGrow
+        label="Send a message"
+        name="longMessage"
+        onChange={setMessage}
+        placeholder="How are you?"
+        value={message}
+      />
+    </form>
+  );
+}
+
+export default Example;

--- a/packages/docs/next-doc-site/pages/components/form-elements.mdx
+++ b/packages/docs/next-doc-site/pages/components/form-elements.mdx
@@ -12,6 +12,7 @@ import Imports from '../../components/imports';
 import playgroundConfig from '../../examples/form-elements/playground-config';
 import SimpleSelect from '../../examples/form-elements/simple-select';
 import BasicTextarea from '../../examples/form-elements/basic-textarea';
+import AutoGrowTextArea from '../../examples/form-elements/auto-grow-textarea';
 import MultipleCheckboxes from '../../examples/form-elements/multiple-checkboxes';
 import BasicSwitch from '../../examples/form-elements/basic-switch';
 import EmptySwitch from '../../examples/form-elements/empty-switch';
@@ -59,6 +60,10 @@ Waffles exposes several form elements:
 
 <Example title="Basic textarea" path="form-elements/basic-textarea">
   <BasicTextarea />
+</Example>
+
+<Example title="Auto-grow textarea" path="form-elements/auto-grow-textarea">
+  <AutoGrowTextArea />
 </Example>
 
 <Example title="Multiple checkboxes" path="form-elements/multiple-checkboxes">

--- a/packages/docs/storybook/stories/form-elements.stories.js
+++ b/packages/docs/storybook/stories/form-elements.stories.js
@@ -363,6 +363,21 @@ storiesOf('waffles-form-elements', module)
               </tr>
             </tbody>
           </table>
+          <div>
+            <label htmlFor="story5">custom label</label>
+            <TextArea
+              autoGrow
+              id="story5"
+              name="story5"
+              onChange={() => {}}
+              placeholder="autoGrow"
+              value={`some
+not so long
+multiline
+pre-formatted
+text`}
+            />
+          </div>
         </div>
       );
     });
@@ -427,6 +442,19 @@ storiesOf('waffles-form-elements', module)
             placeholder="with error"
             required
             value=""
+          />
+          <TextArea
+            autoGrow
+            id="story5"
+            label="TextArea with autoGrow enabled"
+            name="story5"
+            onChange={() => {}}
+            placeholder="autoGrow"
+            value={`some
+not so long
+multiline
+pre-formatted
+text`}
           />
         </div>
       );

--- a/packages/react-components/form-elements/src/TextArea/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/form-elements/src/TextArea/__snapshots__/index.spec.tsx.snap
@@ -1,5 +1,213 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`snapshots renders additional supporting elements to make auto-grow work 1`] = `
+.emotion-0 {
+  border: 0;
+  display: block;
+  margin: 0;
+  margin-top: 0;
+  min-width: 0;
+  padding: 0;
+}
+
+*:not(style)~.emotion-0 {
+  margin-top: 16px;
+}
+
+.emotion-1 {
+  display: block;
+  margin-bottom: 12px;
+  padding: 0;
+  width: 100%;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.emotion-3 {
+  -webkit-font-smoothing: antialiased;
+  color: #05192D;
+  font-family: Studio-Feixen-Sans,Arial,sans-serif;
+  font-style: normal;
+  font-size: 14px;
+  font-weight: 400;
+  color: #05192d;
+  display: inline-block;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+  font-weight: 800;
+  margin-right: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.emotion-4 {
+  display: grid;
+}
+
+.emotion-5 {
+  font-size: 16px;
+  padding-bottom: 12px;
+  padding-top: 12px;
+  resize: none;
+  padding-left: 16px;
+  padding-right: 16px;
+  background: white;
+  border: 0;
+  border-radius: 4px;
+  box-shadow: inset 0 0 0 2px rgb(229, 225, 218);
+  box-sizing: border-box;
+  display: inline-block;
+  font-family: Arial;
+  font-family: Studio-Feixen-Sans;
+  margin: 0;
+  vertical-align: baseline;
+  -webkit-appearance: none;
+  color: rgb(5, 25, 45);
+  width: 100%;
+  grid-area: 1/1/2/2;
+}
+
+.emotion-5:disabled,
+.emotion-5:active:disabled,
+.emotion-5:focus:disabled {
+  cursor: not-allowed;
+  opacity: 0.3;
+}
+
+.emotion-5:focus {
+  box-shadow: inset 0 0 0 2px rgb(0, 155, 216);
+  outline: none;
+}
+
+.emotion-5::-webkit-input-placeholder {
+  color: rgba(5, 25, 45, 0.6);
+  font-family: inherit;
+}
+
+.emotion-5::-moz-placeholder {
+  color: rgba(5, 25, 45, 0.6);
+  font-family: inherit;
+}
+
+.emotion-5:-ms-input-placeholder {
+  color: rgba(5, 25, 45, 0.6);
+  font-family: inherit;
+}
+
+.emotion-5::placeholder {
+  color: rgba(5, 25, 45, 0.6);
+  font-family: inherit;
+}
+
+.emotion-6 {
+  font-size: 16px;
+  padding-bottom: 12px;
+  padding-top: 12px;
+  resize: none;
+  padding-left: 16px;
+  padding-right: 16px;
+  background: white;
+  border: 0;
+  border-radius: 4px;
+  box-shadow: inset 0 0 0 2px rgb(229, 225, 218);
+  box-sizing: border-box;
+  display: inline-block;
+  font-family: Arial;
+  font-family: Studio-Feixen-Sans;
+  margin: 0;
+  vertical-align: baseline;
+  -webkit-appearance: none;
+  color: rgb(5, 25, 45);
+  width: 100%;
+  grid-area: 1/1/2/2;
+  visibility: hidden;
+  white-space: pre-wrap;
+}
+
+.emotion-6:disabled,
+.emotion-6:active:disabled,
+.emotion-6:focus:disabled {
+  cursor: not-allowed;
+  opacity: 0.3;
+}
+
+.emotion-6:focus {
+  box-shadow: inset 0 0 0 2px rgb(0, 155, 216);
+  outline: none;
+}
+
+.emotion-6::-webkit-input-placeholder {
+  color: rgba(5, 25, 45, 0.6);
+  font-family: inherit;
+}
+
+.emotion-6::-moz-placeholder {
+  color: rgba(5, 25, 45, 0.6);
+  font-family: inherit;
+}
+
+.emotion-6:-ms-input-placeholder {
+  color: rgba(5, 25, 45, 0.6);
+  font-family: inherit;
+}
+
+.emotion-6::placeholder {
+  color: rgba(5, 25, 45, 0.6);
+  font-family: inherit;
+}
+
+<label
+  class="emotion-0"
+>
+  <span
+    class="emotion-1"
+  >
+    <span
+      class="emotion-2"
+    >
+      <span
+        class="emotion-3"
+      >
+        test label
+      </span>
+    </span>
+  </span>
+  <div
+    class="emotion-4"
+  >
+    <textarea
+      class="emotion-5"
+      name="input text"
+      placeholder="input text"
+      rows="2"
+    >
+      Some example value
+    </textarea>
+    <div
+      aria-hidden="true"
+      class="emotion-6"
+    >
+      Some example value 
+    </div>
+  </div>
+</label>
+`;
+
 exports[`snapshots renders an input with size disabled=false, required=false 1`] = `
 .emotion-0 {
   border: 0;

--- a/packages/react-components/form-elements/src/TextArea/index.spec.tsx
+++ b/packages/react-components/form-elements/src/TextArea/index.spec.tsx
@@ -1,9 +1,7 @@
 import '@testing-library/jest-dom/extend-expect';
 
-import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
 import { fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 
 import TextArea from '.';
 
@@ -289,5 +287,19 @@ describe('snapshots', () => {
         expect(container.firstChild).toMatchSnapshot();
       });
     });
+  });
+
+  it('renders additional supporting elements to make auto-grow work', () => {
+    const { container } = render(
+      <TextArea
+        autoGrow
+        label="test label"
+        name={exampleText}
+        onChange={() => {}}
+        placeholder={exampleText}
+        value="Some example value"
+      />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/packages/react-components/form-elements/src/TextArea/index.tsx
+++ b/packages/react-components/form-elements/src/TextArea/index.tsx
@@ -179,6 +179,7 @@ const InternalTextArea = ({
       {inputElement}
       <div
         aria-hidden="true"
+        className={className}
         css={css(textAreaStyle, fauxGrowElementStyle)}
       >{`${value} `}</div>
     </div>

--- a/packages/react-components/form-elements/src/TextArea/index.tsx
+++ b/packages/react-components/form-elements/src/TextArea/index.tsx
@@ -174,6 +174,7 @@ const InternalTextArea = ({
     />
   );
 
+  // Add space at the end of faux element content to prevent 'jumping'
   const enhancedInputElement = autoGrow ? (
     <div css={growWrapperStyle}>
       {inputElement}

--- a/packages/react-components/form-elements/src/TextArea/index.tsx
+++ b/packages/react-components/form-elements/src/TextArea/index.tsx
@@ -5,11 +5,25 @@ import React, { forwardRef, ReactElement, Ref } from 'react';
 import { fontSizes, inputPaddings, inputStyle } from '../formStyles';
 import Label from '../Label';
 
+const growWrapperStyle = css({
+  display: 'grid',
+});
+
+const fauxGrowElementStyle = css({
+  gridArea: '1 / 1 / 2 / 2',
+  visibility: 'hidden',
+  whiteSpace: 'pre-wrap',
+});
+
 interface TextAreaProps {
   /**
    * Sets the autocomplete attribute on the rendered input element.
    */
   autocomplete?: string;
+  /**
+   * Allows the input's height to expand as much as it needs to in order to contain the current value.
+   */
+  autoGrow?: boolean;
   /**
    * Sets the css className on the rendered element. Can be used to add custom
    * styling.
@@ -96,6 +110,7 @@ interface TextAreaProps {
 }
 
 const InternalTextArea = ({
+  autoGrow = false,
   autocomplete,
   className,
   dataAttributes,
@@ -138,7 +153,12 @@ const InternalTextArea = ({
     <textarea
       autoComplete={autocomplete}
       className={className}
-      css={textAreaStyle}
+      css={css(
+        textAreaStyle,
+        autoGrow && {
+          gridArea: '1 / 1 / 2 / 2',
+        },
+      )}
       disabled={disabled}
       id={id}
       maxLength={maxLength}
@@ -154,6 +174,18 @@ const InternalTextArea = ({
     />
   );
 
+  const enhancedInputElement = autoGrow ? (
+    <div css={growWrapperStyle}>
+      {inputElement}
+      <div
+        aria-hidden="true"
+        css={css(textAreaStyle, fauxGrowElementStyle)}
+      >{`${value} `}</div>
+    </div>
+  ) : (
+    inputElement
+  );
+
   return (
     <>
       {label ? (
@@ -164,10 +196,10 @@ const InternalTextArea = ({
           label={label}
           required={required}
         >
-          {inputElement}
+          {enhancedInputElement}
         </Label>
       ) : (
-        <>{inputElement}</>
+        <>{enhancedInputElement}</>
       )}
     </>
   );

--- a/packages/react-components/form-elements/src/index.tsx
+++ b/packages/react-components/form-elements/src/index.tsx
@@ -1,4 +1,3 @@
-// FIX BROKEN RELEASE
 export { default as Input } from './Input';
 export { default as Select } from './Select';
 export { default as SelectOption } from './Select/Option';


### PR DESCRIPTION
# [WF-559](https://datacamp.atlassian.net/browse/WF-559)

## Proposed changes
Added auto-grow functionality to **TextArea** component. It's enough to pass **autoGrow** prop:
![textarea-auto-grow](https://user-images.githubusercontent.com/20565536/133421686-8b85e6af-fc4c-414e-a075-22c235f3c36c.gif)

Tested in various browsers and with screen readers. Custom styles overrides also work.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- ~[ ] Structural changes reflected in Readme~
- ~[ ] Migration plan for breaking changes~

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [x] Approved by Designer, Engineer, & PO
