### PR TITLE
[WF-563] Fix password input

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label PRs
-        uses: adamzolyak/monorepo-pr-labeler-action@patching
+        uses: adamzolyak/monorepo-pr-labeler-action
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_DIRS: 'packages/docs|packages/other|packages/react-components|packages/tools'

--- a/packages/react-components/form-elements/src/Input/index.tsx
+++ b/packages/react-components/form-elements/src/Input/index.tsx
@@ -187,6 +187,7 @@ const InternalInput = ({
     inputStyle,
     icon && inputWithIconPaddings[size],
     label && css({ width: '100%' }),
+    type === 'password' && css({ paddingRight: 48 }),
   );
 
   const iconStyle = css({
@@ -217,19 +218,23 @@ const InternalInput = ({
           opacity: 1,
           outline: 0,
         },
+        alignItems: 'center',
         background: 'transparent',
         border: 0,
         color: tokens.color.primary.navyText.value.hex,
-        display: 'block',
+        display: 'flex',
+        height: '100%',
+        justifyContent: 'center',
         opacity: 0.5,
         position: 'absolute',
-        right: 12,
-        top: 11,
+        right: 8,
+        top: 0,
+        width: 36,
       }}
       onClick={togglePasswordVisibility}
       type="button"
     >
-      <i aria-hidden="true">
+      <i aria-hidden="true" css={css({ display: 'flex' })}>
         {passwordVisible ? (
           <HiddenIcon size="medium" />
         ) : (


### PR DESCRIPTION
# [WF-563](https://datacamp.atlassian.net/browse/WF-563)

## Proposed changes
Fixed icon placement and right padding for **password** input type:

<img width="616" alt="password-input" src="https://user-images.githubusercontent.com/20565536/134327910-01a8d37f-640f-4b0a-949d-4886c8017bb3.png">

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- ~[ ] Unit tests written & pass CI~
- ~[ ] Integration tests written & pass CI~
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- ~[ ] Technical docs written~
- ~[ ] Structural changes reflected in Readme~
- ~[ ] Migration plan for breaking changes~

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [x] Approved by Designer, Engineer, & PO
