### PR TITLE
feat(input): pass through HTML attributes

### DIFF
--- a/packages/react-components/form-elements/src/Input/index.tsx
+++ b/packages/react-components/form-elements/src/Input/index.tsx
@@ -95,6 +95,10 @@ interface InputProps {
    */
   onFocus?: () => void;
   /**
+   * Pattern option for browser-based validation of HTML inputs.
+   */
+  pattern?: string;
+  /**
    * The placeholder text to render before the user has entered a value.
    */
   placeholder?: string;
@@ -113,6 +117,10 @@ interface InputProps {
    * The step size for a number input.
    */
   step?: string | number;
+  /**
+   * Title text that is shown as an error prompt when pattern validation doesn't match
+   */
+  title?: string;
   /**
    * The type of input to render. This corresponds to a set of html input types.
    */
@@ -156,10 +164,12 @@ const InternalInput = ({
   onBlur,
   onChange,
   onFocus,
+  pattern,
   placeholder,
   required,
   size = 'medium',
   step,
+  title,
   type = 'text',
   value,
 }: InputProps & { innerRef?: Ref<HTMLInputElement> }): ReactElement => {
@@ -258,10 +268,12 @@ const InternalInput = ({
         onBlur={handleBlur}
         onChange={handleChange}
         onFocus={handleFocus}
+        pattern={pattern}
         placeholder={placeholder}
         ref={innerRef}
         required={htmlRequired}
         step={step}
+        title={title}
         type={type === 'password' && passwordVisible ? 'input' : type}
         value={value}
         {...parsedDataAttributes}


### PR DESCRIPTION
## Proposed changes
The goal of this change is to allow more HTML attributes to be passed through to an `<input />` element. The reasoning is additional browser-based form validation. We currently allow for `required` to be passed for a similar reason. In a perfect world, we'd refactor and allow any HTML attributes to be passed, but this current change would allow for us to not replicate the input component. 

## Functional Code

- [ ] Builds without errors
- [ ] Linter passes CI
- [ ] Unit tests written & pass CI
- [ ] Integration tests written & pass CI
- [ ] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [ ] Technical docs written
- [ ] Structural changes reflected in Readme
- [ ] Migration plan for breaking changes

## Meets Product Requirement

- [ ] Assumptions are met
- [ ] Meets acceptance criteria
- [ ] Approved by Designer, Engineer, & PO
