### PR TITLE
[WF-572] Heap support

### DIFF
--- a/packages/react-components/button/src/UserAccountMenu/Avatar.tsx
+++ b/packages/react-components/button/src/UserAccountMenu/Avatar.tsx
@@ -33,6 +33,7 @@ const Avatar = ({ avatarUrl }: AvatarProps): JSX.Element => {
       <img
         alt=""
         css={imageStyle}
+        data-heap-redact-attributes="src"
         data-testid="user-account-menu-avatar"
         onError={() => setHasImgError(true)}
         src={imgSrc}

--- a/packages/react-components/button/src/UserAccountMenu/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/button/src/UserAccountMenu/__snapshots__/index.spec.tsx.snap
@@ -236,6 +236,7 @@ exports[`UserAccountMenu snapshots renders correctly when all optional props are
       <img
         alt=""
         class="emotion-3"
+        data-heap-redact-attributes="src"
         data-testid="user-account-menu-avatar"
         src="taylor-swift-pic.jpg"
       />
@@ -283,6 +284,7 @@ exports[`UserAccountMenu snapshots renders correctly when all optional props are
         >
           <a
             class="emotion-11"
+            data-heap-redact-attributes="href"
             data-trackid="track-menu-my-profile"
             href="https://datacamp.com/profile/taylorswift"
             role="menuitem"
@@ -517,6 +519,7 @@ exports[`UserAccountMenu snapshots renders correctly when only main app URL is p
       <img
         alt=""
         class="emotion-3"
+        data-heap-redact-attributes="src"
         data-testid="user-account-menu-avatar"
         src="data:image/svg+xml;base64,default-avatar"
       />
@@ -741,6 +744,7 @@ exports[`UserAccountMenu snapshots renders correctly when only main app URL is p
       <img
         alt=""
         class="emotion-3"
+        data-heap-redact-attributes="src"
         data-testid="user-account-menu-avatar"
         src="data:image/svg+xml;base64,default-avatar"
       />

--- a/packages/react-components/button/src/UserAccountMenu/index.tsx
+++ b/packages/react-components/button/src/UserAccountMenu/index.tsx
@@ -81,6 +81,7 @@ function UserAccountMenu({
     >
       {userSlug && (
         <MenuItem
+          data-heap-redact-attributes="href"
           data-trackid={menuMyProfileTrackId}
           href={`${mainAppUrl}/profile/${userSlug}`}
           icon={UserIcon}

--- a/packages/react-components/card/package.json
+++ b/packages/react-components/card/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.1",
     "@datacamp/waffles-tokens": "^2.0.0-beta.5",
+    "@datacamp/waffles-utils": "^3.3.1",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/react-components/card/src/index.spec.tsx
+++ b/packages/react-components/card/src/index.spec.tsx
@@ -186,4 +186,16 @@ describe('<Card />', () => {
         });
       });
   });
+
+  it('sets the dataAttributes on the card element', async () => {
+    const { container } = await axeRender(
+      <Card as="section" dataAttributes={{ test: 'example' }}>
+        <p>{testText}</p>
+      </Card>,
+    );
+
+    const cardElement = container.querySelector('section');
+
+    expect(cardElement).toHaveAttribute('data-test', 'example');
+  });
 });

--- a/packages/react-components/card/src/index.tsx
+++ b/packages/react-components/card/src/index.tsx
@@ -1,6 +1,6 @@
-// FIX BROKEN RELEASE
 /* eslint-disable filenames/match-exported */
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
+import { computeDataAttributes } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
 
 export const elevationMap = {
@@ -41,6 +41,10 @@ interface CardProps {
    */
   className?: string;
   /**
+   * Can be used to set data- html attributes on the element.
+   */
+  dataAttributes?: { [key: string]: string };
+  /**
    * The border/shadow to use on the Card. 0 corresponds to a border, and the
    * other values correspond to levels of shadow.
    */
@@ -64,12 +68,15 @@ function Card({
   as: Element = 'div',
   children,
   className,
+  dataAttributes,
   elevation = 0,
   headStone,
   hoverElevation,
   id,
   onClick,
 }: CardProps): JSX.Element {
+  const parsedDataAttributes = computeDataAttributes(dataAttributes);
+
   return (
     <Element
       className={className}
@@ -89,6 +96,7 @@ function Card({
       )}
       id={id}
       onClick={onClick}
+      {...parsedDataAttributes}
     >
       {headStone && <div css={headStoneStyle}>{headStone}</div>}
       {children}

--- a/packages/react-components/form-elements/src/CheckboxList/Checkbox.tsx
+++ b/packages/react-components/form-elements/src/CheckboxList/Checkbox.tsx
@@ -1,6 +1,9 @@
 import { Text } from '@datacamp/waffles-text';
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
-import { ssrSafeNotFirstChildSelector } from '@datacamp/waffles-utils';
+import {
+  computeDataAttributes,
+  ssrSafeNotFirstChildSelector,
+} from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
 import React, { ReactElement } from 'react';
 
@@ -12,6 +15,10 @@ export interface CheckboxProps {
    * The text to display for this item.
    */
   children: string;
+  /**
+   * Can be used to set data- html attributes on the element.
+   */
+  dataAttributes?: { [key: string]: string };
   /**
    * When true this individual option will be disabled. This is overriden when
    * disabled is set on CheckboxList itself.
@@ -42,6 +49,7 @@ const divStyle = css({
  */
 const Checkbox = ({
   children,
+  dataAttributes,
   disabled = false,
   value,
 }: CheckboxProps): ReactElement => {
@@ -53,6 +61,7 @@ const Checkbox = ({
   const elementDisabled = disabled || contextValue.disabled;
   const handleChange = (): void => contextValue.onChange(value);
   const isChecked = contextValue.value.includes(value);
+  const parsedDataAttributes = computeDataAttributes(dataAttributes);
 
   const focusColor = contextValue.hasError
     ? tokens.color.primary.redDark.value.hex
@@ -84,6 +93,7 @@ const Checkbox = ({
         name={contextValue.name}
         onChange={handleChange}
         type="checkbox"
+        {...parsedDataAttributes}
       />
       <CheckboxIcon
         checked={isChecked}

--- a/packages/react-components/form-elements/src/CheckboxList/index.spec.tsx
+++ b/packages/react-components/form-elements/src/CheckboxList/index.spec.tsx
@@ -35,6 +35,26 @@ describe('<CheckboxList>', () => {
     expect(item2).toHaveAttribute('name', testName);
   });
 
+  it('sets the dataAttributes on the checkbox element', () => {
+    const { getByLabelText } = render(
+      <CheckboxList
+        label={testLabel}
+        name={testName}
+        onChange={() => {}}
+        value={testValue}
+      >
+        <Checkbox dataAttributes={{ test: 'example' }} value="value1">
+          checkbox 1
+        </Checkbox>
+        <Checkbox value="value2">checkbox 2</Checkbox>
+      </CheckboxList>,
+    );
+
+    const checkbox1 = getByLabelText('checkbox 1', { selector: 'input' });
+
+    expect(checkbox1).toHaveAttribute('data-test', 'example');
+  });
+
   describe('required', () => {
     it('renders the indication "Required" above the checkbox group if required is passed as a prop', () => {
       const { getByText } = render(
@@ -52,6 +72,7 @@ describe('<CheckboxList>', () => {
 
       expect(getByText('Required')).toBeInTheDocument();
     });
+
     it('renders the indication "Optional" above the checkbox group if required=false is passed as a prop', () => {
       const { getByText } = render(
         <CheckboxList

--- a/packages/react-components/form-elements/src/RadioList/Radio.tsx
+++ b/packages/react-components/form-elements/src/RadioList/Radio.tsx
@@ -1,6 +1,9 @@
 import { Text } from '@datacamp/waffles-text';
 import tokens from '@datacamp/waffles-tokens/lib/future-tokens.json';
-import { ssrSafeNotFirstChildSelector } from '@datacamp/waffles-utils';
+import {
+  computeDataAttributes,
+  ssrSafeNotFirstChildSelector,
+} from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
 import React, { ReactElement } from 'react';
 
@@ -16,6 +19,10 @@ export interface RadioProps {
    * Additionaly css className to add to the rendered element
    */
   className?: string;
+  /**
+   * Can be used to set data- html attributes on the element.
+   */
+  dataAttributes?: { [key: string]: string };
   /**
    * When true this individual option will be disabled. This is overriden when
    * disabled is set on RadioList itself.
@@ -52,6 +59,7 @@ const divStyle = css({
 const Radio = ({
   children,
   className,
+  dataAttributes,
   disabled = false,
   htmlRequired,
   value,
@@ -65,6 +73,7 @@ const Radio = ({
 
         const elementDisabled = disabled || contextValue.disabled;
         const handleChange = (): void => contextValue.onChange(value);
+        const parsedDataAttributes = computeDataAttributes(dataAttributes);
 
         const focusStyle = {
           borderColor: contextValue.hasError
@@ -94,6 +103,7 @@ const Radio = ({
               onChange={handleChange}
               required={htmlRequired}
               type="radio"
+              {...parsedDataAttributes}
             />
             <RadioIcon
               checked={contextValue.value === value}

--- a/packages/react-components/form-elements/src/RadioList/index.spec.tsx
+++ b/packages/react-components/form-elements/src/RadioList/index.spec.tsx
@@ -35,6 +35,26 @@ describe('<RadioList>', () => {
     expect(item2).toHaveAttribute('name', testName);
   });
 
+  it('sets the dataAttributes on the checkbox element', () => {
+    const { getByLabelText } = render(
+      <RadioList
+        label={testLabel}
+        name={testName}
+        onChange={() => {}}
+        value={testValue}
+      >
+        <Radio dataAttributes={{ test: 'example' }} value="value1">
+          radio 1
+        </Radio>
+        <Radio value="value2">radio 2</Radio>
+      </RadioList>,
+    );
+
+    const radio1 = getByLabelText('radio 1', { selector: 'input' });
+
+    expect(radio1).toHaveAttribute('data-test', 'example');
+  });
+
   describe('required', () => {
     it('renders the indication "Required" above the radio group if required is passed as a prop', () => {
       const { getByText } = render(

--- a/packages/react-components/toast/package.json
+++ b/packages/react-components/toast/package.json
@@ -55,6 +55,7 @@
     "@datacamp/waffles-button": "^8.0.0-beta.6",
     "@datacamp/waffles-text": "^6.0.0-beta.4",
     "@datacamp/waffles-tokens": "^2.0.0-beta.5",
+    "@datacamp/waffles-utils": "^3.3.1",
     "prop-types": "^15.7.2",
     "react-toastify": "^6.1.0"
   },

--- a/packages/react-components/toast/src/Toast.tsx
+++ b/packages/react-components/toast/src/Toast.tsx
@@ -5,6 +5,7 @@ import {
 } from '@datacamp/waffles-icons';
 import { Heading, Paragraph } from '@datacamp/waffles-text';
 import tokens from '@datacamp/waffles-tokens';
+import { computeDataAttributes } from '@datacamp/waffles-utils';
 import { css } from '@emotion/react';
 
 const colors = {
@@ -40,6 +41,10 @@ interface ToastProps {
    */
   closeToast?: () => void;
   /**
+   * Can be used to set data- html attributes on the element.
+   */
+  dataAttributes?: { [key: string]: string };
+  /**
    * Optional content to display in the toast below title.
    */
   description?: string;
@@ -55,15 +60,21 @@ interface ToastProps {
 
 const Toast = ({
   closeToast,
+  dataAttributes,
   description,
   intent,
   title,
 }: ToastProps): JSX.Element => {
   const Icon = icons[intent];
   const color = colors[intent];
+  const parsedDataAttributes = computeDataAttributes(dataAttributes);
 
   return (
-    <div css={css({ borderColor: color }, wrapperStyle)}>
+    <div
+      css={css({ borderColor: color }, wrapperStyle)}
+      {...parsedDataAttributes}
+      data-testid="toast-wrapper"
+    >
       <Icon css={css({ flexShrink: 0, marginTop: 2 })} title={intent} />
       <div
         css={css({ flexGrow: 1, marginLeft: 12, marginRight: 8, marginTop: 2 })}

--- a/packages/react-components/toast/src/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/toast/src/__snapshots__/index.spec.tsx.snap
@@ -120,6 +120,7 @@ exports[`toast mounts a success toast 1`] = `
 >
   <div
     class="emotion-0"
+    data-testid="toast-wrapper"
   >
     <svg
       aria-hidden="false"
@@ -290,6 +291,7 @@ exports[`toast mounts an error toast 1`] = `
 >
   <div
     class="emotion-0"
+    data-testid="toast-wrapper"
   >
     <svg
       aria-hidden="false"

--- a/packages/react-components/toast/src/index.spec.tsx
+++ b/packages/react-components/toast/src/index.spec.tsx
@@ -56,4 +56,17 @@ describe('toast', () => {
     expect(titleElement).toBeInTheDocument();
     expect(descriptionElement).toBeInTheDocument();
   });
+
+  it('sets the dataAttributes on the toast wrapper element', () => {
+    const title = 'test toast title';
+    const { getByTestId } = render(<ToastContainer />);
+    toast({ dataAttributes: { test: 'example' }, intent: 'success', title });
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const toastWrapper = getByTestId('toast-wrapper');
+
+    expect(toastWrapper).toHaveAttribute('data-test', 'example');
+  });
 });

--- a/packages/react-components/toast/src/index.tsx
+++ b/packages/react-components/toast/src/index.tsx
@@ -1,4 +1,3 @@
-// FIX BROKEN RELEASE
 import { toast as toastify, ToastOptions } from 'react-toastify';
 
 import Toast from './Toast';
@@ -6,22 +5,25 @@ import Toast from './Toast';
 export { default as ToastContainer } from './ToastContainer';
 export { default as Toast } from './Toast';
 
+type ToastConfig = {
+  dataAttributes?: { [key: string]: string };
+  description?: string;
+  intent: 'success' | 'error';
+  title: string;
+};
+
 export const toast = (
-  {
-    description,
-    intent,
-    title,
-  }: { description?: string; intent: 'success' | 'error'; title: string },
+  { dataAttributes, description, intent, title }: ToastConfig,
   options?: ToastOptions,
 ): string | number =>
-  toastify(
-    ({ closeToast }: { closeToast: () => void }) => (
+  toastify(({ closeToast }: { closeToast: () => void }) => {
+    return (
       <Toast
         closeToast={closeToast}
+        dataAttributes={dataAttributes}
         description={description}
         intent={intent}
         title={title}
       />
-    ),
-    options,
-  );
+    );
+  }, options);

--- a/packages/react-components/tooltip/src/index.spec.tsx
+++ b/packages/react-components/tooltip/src/index.spec.tsx
@@ -1,9 +1,39 @@
+import '@testing-library/jest-dom/extend-expect';
+
 import axeRender from '@datacamp/waffles-axe-render';
 import React from 'react';
 
 import Tooltip from './index';
 
 describe('Tooltip', () => {
+  it('sets the dataAttributes on the tooltip', async () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { container } = await axeRender(
+      <>
+        <section
+          css={{ height: 50, width: 50 }}
+          data-test-id="target"
+          ref={ref}
+        />
+        <Tooltip
+          appearance="dark"
+          dataAttributes={{ test: 'example' }}
+          id="abc"
+          position="bottom"
+          target={ref}
+          visible
+        >
+          tooltip text content
+        </Tooltip>
+      </>,
+    );
+
+    const tooltipElement = container.querySelector('div');
+
+    expect(tooltipElement).toBeInTheDocument();
+    expect(tooltipElement).toHaveAttribute('data-test', 'example');
+  });
+
   ([
     'bottomLeft',
     'bottom',

--- a/packages/react-components/tooltip/src/index.tsx
+++ b/packages/react-components/tooltip/src/index.tsx
@@ -1,4 +1,3 @@
-// FIX BROKEN RELEASE
 /* eslint-disable filenames/match-exported */
 import Card from '@datacamp/waffles-card';
 import { usePositioner } from '@datacamp/waffles-positioner';
@@ -16,6 +15,10 @@ interface TooltipProps {
    * The text to appear inside the tooltip
    */
   children: string;
+  /**
+   * Can be used to set data- html attributes on the element.
+   */
+  dataAttributes?: { [key: string]: string };
   /**
    * HTML id attribute to use on the rendered element. This is mandatory,
    * since aria-describedby must be set on the target element.
@@ -66,6 +69,7 @@ const elevations = { dark: 0, light: 2 } as const;
 const Tooltip = ({
   appearance,
   children,
+  dataAttributes,
   id,
   position,
   target,
@@ -93,6 +97,7 @@ const Tooltip = ({
         },
         cardStyles[appearance],
       )}
+      dataAttributes={dataAttributes}
       elevation={elevations[appearance]}
       id={id}
     >


### PR DESCRIPTION
# [WF-572](https://datacamp.atlassian.net/browse/WF-572)

## Proposed changes

More components now accept **data** props:
* **Card**
* **Checkbox**
* **Radio**
* **Toast**
* **Tooltip**

Directly added Heap data attributes to _avatar image_ and _my profile link_ in **UserAccountMenu**.

**Switch** and **MenuItem** (UserAccountMenu subcomponent) accept `data-` attributes without custom API so no changes are required there.

Q: Do we need Tooltip inside button to be trackable? If yes, I will have to add something like `tooltipDataAttributes` there.

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- ~[ ] Integration tests written & pass CI~
- ~[ ] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)~

## Documentation

- ~[ ] Technical docs written~
- ~[ ] Structural changes reflected in Readme~
- ~[ ] Migration plan for breaking changes~

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [x] Approved by Designer, Engineer, & PO
