### PR TITLE
Profile link onClick handler

### DIFF
--- a/packages/react-components/button/src/UserAccountMenu/index.spec.tsx
+++ b/packages/react-components/button/src/UserAccountMenu/index.spec.tsx
@@ -128,6 +128,23 @@ describe('UserAccountMenu', () => {
     );
   });
 
+  it("when profile menu item is clicked it's onClick handler is called", () => {
+    const handleClick = jest.fn();
+    const { getByTestId, getByText } = render(
+      <UserAccountMenu
+        mainAppUrl="https://datacamp.com"
+        profileLinkOnClick={handleClick}
+        userSlug="taylorswift"
+      />,
+    );
+    const button = getByTestId('user-account-menu-button');
+    fireEvent.click(button);
+    const profileLink = getByText('My Profile');
+    fireEvent.click(profileLink);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
   it('renders profile image, XP indicator, my profile, account settings, and logout links, when menu is opened and all user props are passed', () => {
     const { getByTestId, getByText } = render(
       <UserAccountMenu

--- a/packages/react-components/button/src/UserAccountMenu/index.tsx
+++ b/packages/react-components/button/src/UserAccountMenu/index.tsx
@@ -45,6 +45,10 @@ type UserAccountMenuProps = {
    */
   menuTriggerTrackId?: string;
   /**
+   * Handler called when the profile link is clicked.
+   */
+  profileLinkOnClick?: (event?: React.MouseEvent<HTMLAnchorElement>) => void;
+  /**
    * URL of user profile page.
    */
   profileUrl?: string;
@@ -75,6 +79,7 @@ function UserAccountMenu({
   menuLogOutTrackId,
   menuMyProfileTrackId,
   menuTriggerTrackId,
+  profileLinkOnClick,
   profileUrl,
   showAlertDot,
   userAvatarUrl,
@@ -99,6 +104,7 @@ function UserAccountMenu({
           data-trackid={menuMyProfileTrackId}
           href={adjustedProfileUrl}
           icon={UserIcon}
+          onClick={profileLinkOnClick}
         >
           My Profile
         </MenuItem>


### PR DESCRIPTION
## Proposed changes

As a workaround to handle client side navigation, added custom onClick handler (**profileLinkOnClick**) for My Profile link. 

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- [x] Integration tests written & pass CI
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- ~[ ] Technical docs written~
- ~[ ] Structural changes reflected in Readme~
- ~[ ] Migration plan for breaking changes~

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [x] Approved by Designer, Engineer, & PO
