### PR TITLE
Adjustable Dialog background color

### DIFF
--- a/packages/react-components/modals/src/AlertDialog/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/AlertDialog/__snapshots__/index.spec.tsx.snap
@@ -146,6 +146,7 @@ exports[`<AlertModal /> isOpen renders the modal via a portal when true 1`] = `
   -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
   transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
   box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25),0 8px 12px -4px rgba(5,25,45,0.3);
+  background-color: #FFFFFF;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/packages/react-components/modals/src/BaseDialog/index.tsx
+++ b/packages/react-components/modals/src/BaseDialog/index.tsx
@@ -25,6 +25,10 @@ interface DialogProps {
    */
   additionalContent?: React.ReactNode;
   /**
+   * The background color of the dialog
+   */
+  backgroundColor?: string;
+  /**
    * The content of the BaseDialog
    */
   children: React.ReactNode;
@@ -79,6 +83,7 @@ export type CloseOrigin = 'overlayClick' | 'escKey' | 'closeButton';
 
 const BaseDialog: React.FC<DialogProps> = ({
   additionalContent,
+  backgroundColor = tokens.colors.white,
   children,
   closeButtonDisabled = false,
   contentLabel,
@@ -145,6 +150,7 @@ const BaseDialog: React.FC<DialogProps> = ({
             )}
             <Card
               css={{
+                backgroundColor,
                 display: 'flex',
                 flexDirection: 'column',
                 maxHeight: '100%',

--- a/packages/react-components/modals/src/Dialog/__snapshots__/index.spec.tsx.snap
+++ b/packages/react-components/modals/src/Dialog/__snapshots__/index.spec.tsx.snap
@@ -146,6 +146,7 @@ exports[`<Dialog /> isOpen renders the modal via a portal when true 1`] = `
   -webkit-transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
   transition: all 600ms cubic-bezier(0.075, 0.82, 0.165, 1);
   box-shadow: 0 0 2px 0 rgba(5, 25, 45, 0.25),0 8px 12px -4px rgba(5,25,45,0.3);
+  background-color: #FFFFFF;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/packages/react-components/modals/src/Dialog/index.tsx
+++ b/packages/react-components/modals/src/Dialog/index.tsx
@@ -1,3 +1,4 @@
+import tokens from '@datacamp/waffles-tokens';
 import React from 'react';
 
 import BaseDialog, { CloseOrigin } from '../BaseDialog';
@@ -8,6 +9,10 @@ import Header from '../shared/Header';
 import StepsIndicator from './StepsIndicator';
 
 interface DialogProps {
+  /**
+   * The background color of the dialog
+   */
+  backgroundColor?: string;
   /**
    * The content of the dialog to render
    */
@@ -60,6 +65,7 @@ interface DialogProps {
 }
 
 const Dialog = ({
+  backgroundColor = tokens.colors.white,
   children,
   currentStep,
   hideCloseButton = false,
@@ -77,6 +83,7 @@ const Dialog = ({
         <StepsIndicator currentStep={currentStep} totalSteps={totalSteps} />
       )
     }
+    backgroundColor={backgroundColor}
     contentLabel="Dialog"
     hideCloseButton={hideCloseButton}
     isOpen={isOpen}


### PR DESCRIPTION
## Proposed changes

Add `backgroundColor` prop to `Dialog` component to unlock paywall feature in campus. I noticed **campus-app** is using  beta package, therefore making beta release too.

Mandatory ugly example with red background:
<img width="656" alt="Screenshot 2022-07-29 at 12 05 36" src="https://user-images.githubusercontent.com/20565536/181737582-1be1b0e3-7697-4356-833d-8ead04b282eb.png">

## Functional Code

- [x] Builds without errors
- [x] Linter passes CI
- [x] Unit tests written & pass CI
- ~[ ] Integration tests written & pass CI~
- [x] Tested on [supported browsers](https://support.datacamp.com/hc/en-us/articles/360001541574-Minimum-System-Requirements)

## Documentation

- [x] Technical docs written
- ~[ ] Structural changes reflected in Readme~
- ~[ ] Migration plan for breaking changes~

## Meets Product Requirement

- [x] Assumptions are met
- [x] Meets acceptance criteria
- [x] Approved by Designer, Engineer, & PO
